### PR TITLE
housekeeping

### DIFF
--- a/.github/workflows/test-monorepo.yml
+++ b/.github/workflows/test-monorepo.yml
@@ -18,3 +18,20 @@ jobs:
           yarn install --immutable
           yarn plugin import workspace-tools
           ../action-npm-publish/scripts/main.sh
+  checkout_publish_skunkworks_dry_run_skip:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          repository: MetaMask/snaps-skunkworks
+          ref: 2befb570c72fddd577410b0193982332eed0fc41
+          path: skunkworks
+      - uses: actions/checkout@v3
+        with:
+          path: action-npm-publish
+      - name: Setup, Build, Publish
+        run: |
+          cd skunkworks
+          yarn install --immutable
+          yarn plugin import workspace-tools
+          NPM_TOKEN=test ../action-npm-publish/scripts/main.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,10 +5,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 14
       - run: |
-          npm install
+          yarn install
           yarn lint:eslint
-          npm test
+          yarn test

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test": "test"
   },
   "engines": {
-    "node": "^14.0.0"
+    "node": "^16.0.0"
   },
   "devDependencies": {
     "@metamask/eslint-config": "^9.0.0",

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -4,6 +4,10 @@ set -x
 set -e
 set -o pipefail
 
+semver_to_nat () {
+  echo "${1//./}"
+}
+
 if [[ -z $NPM_TOKEN ]]; then
   echo "Notice: NPM_TOKEN environment variable not set. Running 'npm publish --dry-run'."
   npm publish --dry-run
@@ -15,9 +19,15 @@ if [[ -n "$1" ]]; then
   # check if module is published
   LATEST_PACKAGE_VERSION=$(npm view . version --workspaces=false || echo "")
   CURRENT_PACKAGE_VERSION=$(jq --raw-output .version package.json)
+  # convert to natural numbers for below comparison
+  LATEST_PACKAGE_VERSION_NAT=$(semver_to_nat "$LATEST_PACKAGE_VERSION")
+  CURRENT_PACKAGE_VERSION_NAT=$(semver_to_nat "$CURRENT_PACKAGE_VERSION")
 
-  if [ "$LATEST_PACKAGE_VERSION" = "$CURRENT_PACKAGE_VERSION" ]; then
-    echo "Notice: This module is already published at $CURRENT_PACKAGE_VERSION. aborting publish."
+  if [ "$LATEST_PACKAGE_VERSION_NAT" -ge "$CURRENT_PACKAGE_VERSION_NAT" ]; then
+    echo -e \
+      "Notice: This module cannot be published at v$CURRENT_PACKAGE_VERSION." \
+      "This module has been already published at v$LATEST_PACKAGE_VERSION." \
+      "aborting publish."
     exit 0
   fi
 fi

--- a/test/index.js
+++ b/test/index.js
@@ -3,12 +3,9 @@ const { exec } = require('child_process');
 const { test } = require('tapzero');
 const package = require('../package.json');
 
-const { devDependencies, name, version } = package;
-const NPM_404_ERROR = `npm ERR! 404 '${name}' is not in the npm registry.`;
+const { devDependencies, version } = package;
 const INVALID_TOKEN = 'should error when token is invalid';
 const FAKE = 'FAKE';
-
-const includesError = (error) => error.toString().includes(NPM_404_ERROR);
 
 test('should not have dependencies from now until forever', async (t) => {
   const depKey = 'dependencies';
@@ -52,32 +49,6 @@ test('should error when token is invalid', async (t) => {
         reject(new Error(INVALID_TOKEN));
       }
       t.equal(error.code, 1);
-      resolve();
-    });
-  });
-});
-
-test('should check before publish when param is used', async (t) => {
-  await new Promise((resolve, reject) => {
-    exec(`NPM_TOKEN=${FAKE} ./scripts/publish.sh true`, (error) => {
-      if (!error) {
-        reject(new Error(INVALID_TOKEN));
-      }
-
-      t.equal(includesError(error), true);
-      resolve();
-    });
-  });
-});
-
-test('should not check before publish when param is omitted', async (t) => {
-  await new Promise((resolve, reject) => {
-    exec(`NPM_TOKEN=${FAKE} ./scripts/publish.sh`, (error) => {
-      if (!error) {
-        reject(new Error(INVALID_TOKEN));
-      }
-
-      t.equal(includesError(error), false);
       resolve();
     });
   });


### PR DESCRIPTION
I was taking a closer look at this last night and wanted to button up a few things:
- update to use latest stable
- test the full skip functionality in ci after standardising this to use latest stable
- standardise on `yarn` for test workflow
- previously the skip functionality only worked if the module version you were trying to publish was equal to the currently published version (which was honestly probably fine), but here I've made a change so it will also skip if the version you're trying to publish is even older than that.
- I've also updated the notice for that scenario so it surfaces a bit more details:
```
Notice: This module cannot be published at 0.16.0. This module has been already published at 0.18.1. aborting publish.
```
you can see an example of this in the following workflow run: https://github.com/rickycodes/action-npm-publish/runs/7412228382?check_suite_focus=true