### PR TITLE
Use Yarn for publishing rather than npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 GitHub action to publish an npm module with a provided `npm-token`. If the `npm-token` is omitted the action will perform a dry run npm publish by default.
 
+This action assumes that Yarn is installed and that the package is using Yarn v3. It may fail for other Yarn versions or other package managers.
+
+If your package has a `prepack` script and is using the `node-modules` linker, you will need to ensures that the file `node_modules/.yarn-state.yml` is present before this action is invoked. This file is generated automatically when installing dependencies. If you want to publish without dependencies present, you can instantiate an empty state file or restore one from a cache.
+
 ## Usage
 
 Pass your token to the action:
@@ -34,19 +38,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Get Node.js version
-        id: nvm
-        run: echo ::set-output name=NODE_VERSION::$(cat .nvmrc)
-      - uses: actions/setup-node@v2
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
         with:
-          node-version: ${{ steps.nvm.outputs.NODE_VERSION }}
+          node-version-file: '.nvmrc'
       - run: |
-          yarn setup
+          yarn install
           yarn build
       - uses: actions/cache@v2
         id: restore-build
         with:
-          path: ./*
+          path: |
+            ./dist
+            ./node_modules/.yarn-state.yml
           key: ${{ github.sha }}
   publish-npm-dry-run:
     runs-on: ubuntu-latest
@@ -55,7 +59,9 @@ jobs:
       - uses: actions/cache@v2
         id: restore-build
         with:
-          path: ./*
+          path: |
+            ./dist
+            ./node_modules/.yarn-state.yml
           key: ${{ github.sha }}
       - name: Publish
         # omitting npm-token will perform a dry run publish
@@ -69,7 +75,9 @@ jobs:
       - uses: actions/cache@v2
         id: restore-build
         with:
-          path: ./*
+          path: |
+            ./dist
+            ./node_modules/.yarn-state.yml
           key: ${{ github.sha }}
       - name: Publish
         uses: MetaMask/action-npm-publish@v1

--- a/action.yml
+++ b/action.yml
@@ -12,4 +12,4 @@ runs:
       shell: bash
       run: ${{ github.action_path }}/scripts/main.sh
       env:
-        NPM_TOKEN: ${{ inputs.npm-token }}
+        YARN_NPM_AUTH_TOKEN: ${{ inputs.npm-token }}

--- a/scripts/main.sh
+++ b/scripts/main.sh
@@ -6,10 +6,6 @@ set -o pipefail
 
 script_path=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
 
-if [[ -n $NPM_TOKEN ]]; then
-  npm config set //registry.npmjs.org/:_authToken "${NPM_TOKEN}"
-fi
-
 if [[ "$(jq 'has("workspaces")' package.json)" = "true" ]]; then
   echo "Notice: workspaces detected. Treating as monorepo."
   yarn workspaces foreach --no-private --verbose exec "$script_path/publish.sh true"

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -4,8 +4,8 @@ set -x
 set -e
 set -o pipefail
 
-if [[ -z $NPM_TOKEN ]]; then
-  echo "Notice: NPM_TOKEN environment variable not set. Running 'yarn pack --dry-run'."
+if [[ -z $YARN_NPM_AUTH_TOKEN ]]; then
+  echo "Notice: YARN_NPM_AUTH_TOKEN environment variable not set. Running 'yarn pack --dry-run'."
   yarn pack --dry-run
   exit 0
 fi

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -5,8 +5,8 @@ set -e
 set -o pipefail
 
 if [[ -z $NPM_TOKEN ]]; then
-  echo "Notice: NPM_TOKEN environment variable not set. Running 'npm publish --dry-run'."
-  npm publish --dry-run
+  echo "Notice: NPM_TOKEN environment variable not set. Running 'yarn pack --dry-run'."
+  yarn pack --dry-run
   exit 0
 fi
 
@@ -22,4 +22,4 @@ if [[ -n "$1" ]]; then
   fi
 fi
 
-npm publish
+yarn npm publish

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -5,7 +5,7 @@ set -e
 set -o pipefail
 
 if [[ -z $YARN_NPM_AUTH_TOKEN ]]; then
-  echo "Notice: YARN_NPM_AUTH_TOKEN environment variable not set. Running 'yarn pack --dry-run'."
+  echo "Notice: 'npm-token' not set. Running 'yarn pack --dry-run'."
   yarn pack --dry-run
   exit 0
 fi

--- a/test/index.js
+++ b/test/index.js
@@ -32,11 +32,11 @@ test('should not error when performing a dry-run publish', async (t) => {
 
 test('correct version should appear in dry-run output', async (t) => {
   await new Promise((resolve, reject) => {
-    exec('./scripts/main.sh', (error, __, stderr) => {
+    exec('./scripts/main.sh', (error, stdout) => {
       if (error) {
         reject(new Error(error));
       }
-      t.equal(stderr.includes(version), true);
+      t.equal(stdout.includes(version), true);
       resolve();
     });
   });

--- a/test/index.js
+++ b/test/index.js
@@ -44,7 +44,7 @@ test('correct version should appear in dry-run output', async (t) => {
 
 test('should error when token is invalid', async (t) => {
   await new Promise((resolve, reject) => {
-    exec(`NPM_TOKEN=${FAKE} ./scripts/main.sh`, (error) => {
+    exec(`YARN_NPM_AUTH_TOKEN=${FAKE} ./scripts/main.sh`, (error) => {
       if (!error) {
         reject(new Error(INVALID_TOKEN));
       }


### PR DESCRIPTION
Yarn is now used for publishing rather than npm. This is required when using Yarn-specific dependency protocols such as `workspace:`, which Yarn will resolve before publishing.

The README has been updated to explain the assumptions of this action, and the example has been updated to match these assumptions.