### PR TITLE
Add a way to set a custom NPM registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ Pass your token to the action:
 
 ```yaml
 - name: Publish
-  uses: MetaMask/action-npm-publish@v1
+  uses: MetaMask/action-npm-publish@v2
   with:
     npm-token: ${{ secrets.NPM_TOKEN }}
 ```
 
-To publish an npm module whenever a release PR is merged, you could do something like this:
+To publish an NPM module whenever a release PR is merged, you could add a workflow file like the following to your project. Note that this requires you add a `publish` environment to your repository and set the `NPM_TOKEN` environment variable within that environment to your NPM token:
 
 ```yaml
 name: Publish to npm
@@ -65,7 +65,7 @@ jobs:
           key: ${{ github.sha }}
       - name: Publish
         # omitting npm-token will perform a dry run publish
-        uses: MetaMask/action-npm-publish@v1
+        uses: MetaMask/action-npm-publish@v2
   publish-npm:
     # use a github actions environment
     environment: publish
@@ -80,7 +80,79 @@ jobs:
             ./node_modules/.yarn-state.yml
           key: ${{ github.sha }}
       - name: Publish
-        uses: MetaMask/action-npm-publish@v1
+        uses: MetaMask/action-npm-publish@v2
         with:
           npm-token: ${{ secrets.NPM_TOKEN }}
 ```
+
+If you are making changes to the workflow(s) in your repository and need to test that your package still gets published correctly, you can configure the action to use your own NPM registry instead of the official one. For instance, here is a workflow file that uses [Gemfury](https://gemfury.com/help/npm-registry/):
+
+```yaml
+name: Publish to npm
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  cache-build:
+    permissions:
+      contents: write
+    if: |
+      github.event.pull_request.merged == true &&
+      startsWith(github.event.pull_request.head.ref, 'release/')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Get Node.js version
+        id: nvm
+        run: echo ::set-output name=NODE_VERSION::$(cat .nvmrc)
+      - uses: actions/setup-node@v2
+        with:
+          node-version: ${{ steps.nvm.outputs.NODE_VERSION }}
+      - run: |
+          yarn setup
+          yarn build
+      - uses: actions/cache@v2
+        id: restore-build
+        with:
+          path: ./*
+          key: ${{ github.sha }}
+  publish-npm-dry-run:
+    runs-on: ubuntu-latest
+    needs: cache-build
+    steps:
+      - uses: actions/cache@v2
+        id: restore-build
+        with:
+          path: ./*
+          key: ${{ github.sha }}
+      - name: Publish
+        uses: MetaMask/action-npm-publish@v2
+        with:
+          # omitting npm-token will perform a dry run publish
+          npm-registry: https://npm.fury.io/YOUR-USERNAME-GOES-HERE/
+  publish-npm:
+    # use a github actions environment
+    environment: publish
+    runs-on: ubuntu-latest
+    needs: publish-npm-dry-run
+    steps:
+      - uses: actions/cache@v2
+        id: restore-build
+        with:
+          path: ./*
+          key: ${{ github.sha }}
+      - name: Publish
+        uses: MetaMask/action-npm-publish@v2
+        with:
+          npm-registry: https://npm.fury.io/YOUR-USERNAME-GOES-HERE/
+          npm-token: ${{ secrets.NPM_TOKEN }}
+```
+
+## API
+
+### Inputs
+
+- **`npm-registry`** _(optional; defaults to whatever Yarn's `npmPublishRegistry` option defaults to)_. The URL of the NPM registry that Yarn commands will use to access and publish packages.
+- **`npm-token`** _(optional)_. The auth token associated with the registry that Yarn commands will use to access and publish packages. If omitted, the action will perform a dry-run publish.

--- a/action.yml
+++ b/action.yml
@@ -1,8 +1,11 @@
 name: 'Publish to npm'
 description: 'Publish the release to npm'
 inputs:
+  npm-registry:
+    description: 'The URL of the NPM registry that Yarn commands will use to access and publish packages.'
+    required: false
   npm-token:
-    description: 'The token used for npm publishing. If omitted the action will perform a dry run npm publish.'
+    description: 'The auth token associated with the registry that Yarn commands will use to access and publish packages. If omitted, the action will perform a dry-run publish.'
     required: false
 
 runs:
@@ -12,4 +15,5 @@ runs:
       shell: bash
       run: ${{ github.action_path }}/scripts/main.sh
       env:
+        YARN_NPM_REGISTRY_SERVER: ${{ inputs.npm-registry }}
         YARN_NPM_AUTH_TOKEN: ${{ inputs.npm-token }}


### PR DESCRIPTION
This change makes it possible to test actions that involve publishing of NPM packages because it allows us to point to a private NPM registry. For instance, you could run the action by saying:

``` yaml
- uses: MetaMask/action-npm-publish@v2
  with:
    npm-registry: https://npm.fury.io/yourusernamehere/
    npm-token: ${{ secrets.NPM_TOKEN }}
  env:
    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
```

and now when a package is accessed or published,
[Gemfury](https://gemfury.com/help/npm-registry/) will be used instead of the official NPM registry.