### PR TITLE
Use SHA instead of tag for action consumption

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -25,7 +25,7 @@ runs:
     - name: Post to a Slack channel
       id: slack
       if: inputs.slack-webhook-url != ''
-      uses: slackapi/slack-github-action@v1.22.0
+      uses: slackapi/slack-github-action@007b2c3c751a190b6f0f040e47ed024deaa72844
       with:
         payload: |
           {


### PR DESCRIPTION
as part of our commitment to keeping our action consumption secure this has now been updated to be pinned to a `SHA` instead of a version tag