### PR TITLE
Revert "Revert slack accounce (#22)"

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,22 @@ If you omit `npm-token`, then packages will be prepared for publishing, but no p
 - uses: MetaMask/action-npm-publish@v2
 ```
 
+### Slack announce
+
+You can optionally send deployment announcements to Slack by providing a `slack-webhook-url` input:
+
+```yaml
+- uses: MetaMask/action-npm-publish@v2
+  with:
+    slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+```
+
+![image](https://user-images.githubusercontent.com/675259/203841602-124d537d-7476-4263-a17c-6d05b68c37d0.png)
+
 ## API
 
 ### Inputs
 
 - **`npm-token`** _(optional)_. The auth token associated with the registry that Yarn commands will use to access and publish packages. If omitted, the action will perform a dry-run publish.
+
+- **`slack-webhook-url`** _(optional)_. The incoming webhook URL associated with your Slack application for announcing releases to a Slack channel. This can be added under the "Incoming Webhooks" section of your Slack app configuration. 

--- a/action.yml
+++ b/action.yml
@@ -4,6 +4,9 @@ inputs:
   npm-token:
     description: 'The token used for npm publishing. If omitted the action will perform a dry run npm publish.'
     required: false
+  slack-webhook-url:
+    description: 'Slack Webhook URL'
+    required: false
 
 runs:
   using: 'composite'
@@ -13,3 +16,30 @@ runs:
       run: ${{ github.action_path }}/scripts/main.sh
       env:
         YARN_NPM_AUTH_TOKEN: ${{ inputs.npm-token }}
+    - id: name-version
+      shell: bash
+      if: inputs.slack-webhook-url != ''
+      run: |
+        NAME_VERSION=$(jq --raw-output '.name + "@" + .version' package.json)
+        echo "NAME_VERSION=$NAME_VERSION" >> "$GITHUB_OUTPUT"
+    - name: Post to a Slack channel
+      id: slack
+      if: inputs.slack-webhook-url != ''
+      uses: slackapi/slack-github-action@007b2c3c751a190b6f0f040e47ed024deaa72844
+      with:
+        payload: |
+          {
+            "text": "`${{ steps.name-version.outputs.NAME_VERSION }}` is awaiting deployment :rocket: : https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/",
+            "blocks": [
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": "`${{ steps.name-version.outputs.NAME_VERSION }}` is awaiting deployment :rocket: \n <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/|Click to review>"
+                }
+              }
+            ]
+          }
+      env:
+        SLACK_WEBHOOK_URL: ${{ inputs.slack-webhook-url }}
+        SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK


### PR DESCRIPTION
This reverts commit 27b09de1b68f71fbacb00faf68275feab24dadfa, restoring the Slack announce feature. The feature was temporarily reverted so that we could publish v2.1.1 without it.