### PR TITLE
Add optional npm-tag parameter to action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -4,6 +4,10 @@ inputs:
   npm-token:
     description: 'The token used for npm publishing. If omitted the action will perform a dry run npm publish.'
     required: false
+  npm-tag:
+    description: 'The npm tag to publish to. Defaults to "latest".'
+    required: false
+    default: 'latest'
   slack-webhook-url:
     description: 'Slack Webhook URL'
     required: false
@@ -16,6 +20,7 @@ runs:
       run: ${{ github.action_path }}/scripts/main.sh
       env:
         YARN_NPM_AUTH_TOKEN: ${{ inputs.npm-token }}
+        YARN_NPM_TAG: ${{ inputs.npm-tag }}
     - id: name-version
       shell: bash
       if: inputs.slack-webhook-url != ''

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -10,6 +10,11 @@ if [[ -z $YARN_NPM_AUTH_TOKEN ]]; then
   exit 0
 fi
 
+if [[ -z $YARN_NPM_TAG ]]; then
+  echo "Notice: 'npm-tag' not set."
+  exit 1
+fi
+
 # check param, if it's set (monorepo) we check if it's published before proceeding
 if [[ -n "$1" ]]; then
   # check if module is published
@@ -22,4 +27,4 @@ if [[ -n "$1" ]]; then
   fi
 fi
 
-yarn npm publish
+yarn npm publish --tag "$YARN_NPM_TAG"


### PR DESCRIPTION
## Description

This pull request adds an optional `npm-tag` parameter to the npm publish action, which allows customizing the npm tag
when publishing a package to the npm registry. By default, the tag is set to "latest". 

The `npm-tag` parameter is optional but can be passed as an argument to the npm publish action when running the CI/CD
pipeline. The environment variable `YARN_NPM_TAG` is then passed to the bash script that publishes the 
package.

## Changes

1. Add `npm-tag` parameter to npm publish action.
2. Use `YARN_NPM_TAG` environment variable to customize the npm tag parameter passed to the bash script.