### PR TITLE
Rename `YARN_NPM_TAG` to `PUBLISH_NPM_TAG`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -20,7 +20,7 @@ runs:
       run: ${{ github.action_path }}/scripts/main.sh
       env:
         YARN_NPM_AUTH_TOKEN: ${{ inputs.npm-token }}
-        YARN_NPM_TAG: ${{ inputs.npm-tag }}
+        PUBLISH_NPM_TAG: ${{ inputs.npm-tag }}
     - id: name-version
       shell: bash
       if: inputs.slack-webhook-url != ''

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -10,7 +10,7 @@ if [[ -z $YARN_NPM_AUTH_TOKEN ]]; then
   exit 0
 fi
 
-if [[ -z $YARN_NPM_TAG ]]; then
+if [[ -z $PUBLISH_NPM_TAG ]]; then
   echo "Notice: 'npm-tag' not set."
   exit 1
 fi
@@ -27,4 +27,4 @@ if [[ -n "$1" ]]; then
   fi
 fi
 
-yarn npm publish --tag "$YARN_NPM_TAG"
+yarn npm publish --tag "$PUBLISH_NPM_TAG"


### PR DESCRIPTION
## Description

This pull request renames the `YARN_NPM_TAG` environment variable to `PUBLISH_NPM_TAG`. The reason for doing so is that
environment variables starting with `YARN_` are reserved for Yarn configuration options. Hence, if we use `YARN_NPM_TAG`
as an environment variable, it will cause Yarn to throw an error. On the other hand, `PUBLISH_NPM_TAG` is not
a reserved environment variable name, which makes it a preferred choice.

## Changes

1. Rename `YARN_NPM_TAG` to `PUBLISH_NPM_TAG`.