### PR TITLE
switch package version comparison to yarn

### DIFF
--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -18,7 +18,8 @@ fi
 # check param, if it's set (monorepo) we check if it's published before proceeding
 if [[ -n "$1" ]]; then
   # check if module is published
-  LATEST_PACKAGE_VERSION=$(npm view . version --workspaces=false || echo "")
+  PACKAGE_NAME=$(jq --raw-output .name package.json)
+  LATEST_PACKAGE_VERSION=$(yarn info --json $PACKAGE_NAME | jq --raw-output .children.Version || echo "")
   CURRENT_PACKAGE_VERSION=$(jq --raw-output .version package.json)
 
   if [ "$LATEST_PACKAGE_VERSION" = "$CURRENT_PACKAGE_VERSION" ]; then


### PR DESCRIPTION
Hi there!

I had an issue trying to this action with a private npm registry. I had to add a `.yarnrc.yml` file that contains the private scope & registry but the absence of .npmrc did not allow the action to correctly compare versions. This lead to errors because `npm` was not able to find the private module.

This PRs tries to fix this issue by migrating the comparison to `yarn`.