### PR TITLE
Add new input to support customising the Slack channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,4 +87,4 @@ You can read more about these option in the [API](#API) section below
 - **`icon-url`** _(optional)_. Url to the avatar used for the bot in Slack. If not set this defaults to the avatar in this repository.
 - **`username`** _(optional)_. The name of the bot as it appears on Slack. If not set this defaults to `MetaMask bot`.
 - **`target-name`** _(optional)_. Use this if you want to ping an individual or subset of individuals on Slack using `@`.
-- **`channel`** _(optional)_. Use this if you want to post to a channel other than the default: `#metamask-dev`.
+- **`channel`** _(optional)_. Use this if you want to post to a channel other than the default: `metamask-dev`.

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ We've added the ability to customize the message posted in Slack and those optio
 - `icon-url`
 - `username`
 - `target-name`
+- `channel`
 
 example:
 
@@ -63,9 +64,10 @@ example:
 - uses: MetaMask/action-npm-publish@v2
   with:
     slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
-    icon-url: 'https://ricky.codes/me.jpg'
-    username: 'rickybot'
-    target-name: 'ricky'
+    icon-url: https://ricky.codes/me.jpg
+    username: rickybot
+    target-name: ricky
+    channel: dev-channel
 ```
 
 You can read more about these option in the [API](#API) section below
@@ -85,3 +87,4 @@ You can read more about these option in the [API](#API) section below
 - **`icon-url`** _(optional)_. Url to the avatar used for the bot in Slack. If not set this defaults to the avatar in this repository.
 - **`username`** _(optional)_. The name of the bot as it appears on Slack. If not set this defaults to `MetaMask bot`.
 - **`target-name`** _(optional)_. Use this if you want to ping an individual or subset of individuals on Slack using `@`.
+- **`channel`** _(optional)_. Use this if you want to post to a channel other than the default: `#metamask-dev`.

--- a/action.yml
+++ b/action.yml
@@ -22,6 +22,10 @@ inputs:
   target-name:
     description: 'Use this if you want to ping an individual or subset of individuals on Slack using @'
     required: false
+  channel:
+    description: 'The Slack channel to post in'
+    required: false
+    default: 'metamask-dev'
 
 runs:
   using: 'composite'
@@ -64,7 +68,8 @@ runs:
           {
             "text": "${{ steps.final-text.outputs.FINAL_TEXT }}",
             "icon_url": "${{ inputs.icon-url }}",
-            "username": "${{ inputs.username }}"
+            "username": "${{ inputs.username }}",
+            "channel": "#${{ inputs.channel }}"
           }
       env:
         SLACK_WEBHOOK_URL: ${{ inputs.slack-webhook-url }}


### PR DESCRIPTION
I didn't think we could do this as i thought the bot was restricted to a single channel, but it turns out we can.

Consumers can use this if they wish to post to a channel other than the default.