### PR TITLE
Add functionality for subteams

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -19,8 +19,8 @@ inputs:
     description: 'The name of the bot as it appears on Slack'
     required: false
     default: 'MetaMask bot'
-  target-name:
-    description: 'Use this if you want to ping an individual or subset of individuals on Slack using @'
+  subteam:
+    description: 'Use this if you want to ping a subteam of individuals on Slack using @'
     required: false
   channel:
     description: 'The Slack channel to post in'
@@ -48,10 +48,10 @@ runs:
       if: inputs.slack-webhook-url != ''
       run: |
         DEFAULT_TEXT="\`${{ steps.name-version.outputs.NAME_VERSION }}\` is awaiting deployment :rocket: \n <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/|→ Click here to review deployment>"
-        TARGET_NAME_TEXT="${{ inputs.target-name }}"
+        SUBTEAM_TEXT="${{ inputs.subteam }}"
         FINAL_TEXT="$DEFAULT_TEXT"
-        if [[ ! "$TARGET_NAME_TEXT" == "" ]]; then
-          FINAL_TEXT="<@$TARGET_NAME_TEXT> $DEFAULT_TEXT"
+        if [[ ! "$SUBTEAM_TEXT" == "" ]]; then
+          FINAL_TEXT="<!subteam^$SUBTEAM_TEXT> $DEFAULT_TEXT"
         fi
         echo "FINAL_TEXT=$FINAL_TEXT" >> "$GITHUB_OUTPUT"
     - name: Post to a Slack channel


### PR DESCRIPTION
Okay! our deployment today failed to tag the subteam because I didn't have this configured properly. I had assumed the functionality for tagging individuals and subteams was identical, but I was wrong! see: https://api.slack.com/reference/surfaces/formatting#mentioning-groups

I've tested this out in a private channel in our Slack instance and it works properly:

![image](https://github.com/MetaMask/action-npm-publish/assets/675259/4c048905-fd6a-4ce8-8649-9b25a6735f46)
