### PR TITLE
Use tag to check latest package version

### DIFF
--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -19,7 +19,7 @@ fi
 if [[ -n "$1" ]]; then
   # check if module is published
   PACKAGE_NAME=$(jq --raw-output .name package.json)
-  LATEST_PACKAGE_VERSION=$(yarn info --json "$PACKAGE_NAME" | jq --raw-output .children.Version || echo "")
+  LATEST_PACKAGE_VERSION=$(npm view "$PACKAGE_NAME" dist-tags --workspaces false --json | jq --raw-output --arg tag "$PUBLISH_NPM_TAG" '.[$tag]' || echo "")
   CURRENT_PACKAGE_VERSION=$(jq --raw-output .version package.json)
 
   if [ "$LATEST_PACKAGE_VERSION" = "$CURRENT_PACKAGE_VERSION" ]; then


### PR DESCRIPTION
This uses the `npm-tag` to check for the latest version of the package on NPM.