### PR TITLE
Run linting and testing GitHub workflows on PRs

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -3,7 +3,10 @@ name: shellcheck
 permissions:
   checks: write
 
-on: [push]
+on:
+  push:
+    branches: [main]
+  pull_request:
 
 jobs:
   lint:

--- a/.github/workflows/test-monorepo.yml
+++ b/.github/workflows/test-monorepo.yml
@@ -1,5 +1,8 @@
 name: test-monorepo
-on: [push]
+on:
+  push:
+    branches: [main]
+  pull_request:
 jobs:
   # test npm publish dry-run
   checkout_publish_skunkworks_dry_run:

--- a/.github/workflows/test-polyrepo.yml
+++ b/.github/workflows/test-polyrepo.yml
@@ -1,5 +1,8 @@
 name: test-polyrepo
-on: [push]
+on:
+  push:
+    branches: [main]
+  pull_request:
 jobs:
   # test npm publish dry-run
   checkout_publish_controllers_dry_run:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,8 @@
 name: test
-on: [push]
+on:
+  push:
+    branches: [main]
+  pull_request:
 jobs:
   test:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
Currently, code is not automatically linted and tests are not automatically run on pull requests. This happens because the workflows which would perform these steps are not configured to run on pull requests but only on a push to `main`. This PR modifies the workflows to run on the `pull_request` event.