### PR TITLE
Fix Yarn 4 compatibility

### DIFF
--- a/scripts/main.sh
+++ b/scripts/main.sh
@@ -8,7 +8,7 @@ script_path=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
 
 if [[ "$(jq 'has("workspaces")' package.json)" = "true" ]]; then
   echo "Notice: workspaces detected. Treating as monorepo."
-  yarn workspaces foreach --no-private --verbose exec "$script_path/publish.sh true"
+  yarn workspaces foreach --all --no-private --verbose exec "$script_path/publish.sh true"
   exit 0
 fi
 


### PR DESCRIPTION
Yarn 4's `workspaces foreach` requires `--all` (or another similar option) to be set explicitly:

```
Usage Error: Invalid option schema: missing at least one property from "all", "recursive", "since",
or "worktree"
```

Adding `--all` seems to match the existing behaviour in Yarn 3, and does not break backwards compatibility.