### PR TITLE
Don't fail overall if Slack announcement fails

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -83,3 +83,4 @@ runs:
       env:
         SLACK_WEBHOOK_URL: ${{ inputs.slack-webhook-url }}
         SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+      continue-on-error: true


### PR DESCRIPTION
Typically, for a project, this action is run twice: once in dry-run mode (to allow approvers to review the package before it is published) and another time to issue the approval step and then actually publish the package.

When the action is run in dry-run mode, an announcement on Slack is created in order to notify approvers. If this fails in any way, however, it halts the release workflow completely and prevents the second instance of the action from running. This means that the package can never be released automatically and must be released manually.

This commit fixes this problem by instructing GitHub Actions that it is not mandatory for the Slack announcement step to pass in order for the release workflow to continue.

---

You can see a test for this change on a fork here: https://github.com/mcmire/utils/actions/runs/8990293760/job/24695822650. Note that the action fails and we see the error printed, but the overall step does not fail.

---

Fixes #68.