### PR TITLE
Release 4.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.0.3]
+### Fixed
+- Fix Slack announcement for public default channel ([#73](https://github.com/MetaMask/action-npm-publish/pull/73))
+  - We have found that the Slack announcement does not work correctly for public channels when the `channel` parameter is given. The action has been updated to omit the default if no channel is specified, so that announcements to the default channel work correctly even if it is public.
+
 ## [4.0.2]
 ### Fixed
 - Prevent workflow from failing if Slack announcement step fails ([#69](https://github.com/MetaMask/action-npm-publish/pull/69))
@@ -79,7 +84,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Initial release ([#1](https://github.com/MetaMask/action-npm-publish/pull/1))
 
-[Unreleased]: https://github.com/MetaMask/action-npm-publish/compare/v4.0.2...HEAD
+[Unreleased]: https://github.com/MetaMask/action-npm-publish/compare/v4.0.3...HEAD
+[4.0.3]: https://github.com/MetaMask/action-npm-publish/compare/v4.0.2...v4.0.3
 [4.0.2]: https://github.com/MetaMask/action-npm-publish/compare/v4.0.1...v4.0.2
 [4.0.1]: https://github.com/MetaMask/action-npm-publish/compare/v4.0.0...v4.0.1
 [4.0.0]: https://github.com/MetaMask/action-npm-publish/compare/v3.2.0...v4.0.0

--- a/action.yml
+++ b/action.yml
@@ -25,7 +25,6 @@ inputs:
   channel:
     description: 'The Slack channel to post in'
     required: false
-    default: 'metamask-dev'
 
 runs:
   using: 'composite'
@@ -56,7 +55,7 @@ runs:
         echo "FINAL_TEXT=$FINAL_TEXT" >> "$GITHUB_OUTPUT"
     - name: Post to a Slack channel
       id: slack
-      if: inputs.slack-webhook-url != ''
+      if: ${{ inputs.slack-webhook-url != '' && inputs.channel != '' }}
       uses: slackapi/slack-github-action@007b2c3c751a190b6f0f040e47ed024deaa72844
       with:
         payload: |
@@ -66,6 +65,17 @@ runs:
             "username": "${{ inputs.username }}",
             "channel": "#${{ inputs.channel }}"
           }
+    - name: Post to a default Slack channel
+      id: slack
+      if: ${{ inputs.slack-webhook-url != '' && inputs.channel == '' }}
+      uses: slackapi/slack-github-action@007b2c3c751a190b6f0f040e47ed024deaa72844
+      with:
+        payload: |
+          {
+            "text": "${{ steps.final-text.outputs.FINAL_TEXT }}",
+            "icon_url": "${{ inputs.icon-url }}",
+            "username": "${{ inputs.username }}"
+          }          
       env:
         SLACK_WEBHOOK_URL: ${{ inputs.slack-webhook-url }}
         SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "url": "https://github.com/MetaMask/action-npm-publish/issues"
   },
   "homepage": "https://github.com/MetaMask/action-npm-publish#readme",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "main": "index.js",
   "directories": {
     "test": "test"


### PR DESCRIPTION
## [4.0.3]
### Fixed
- Fix Slack announcement for public default channel ([#73](https://github.com/MetaMask/action-npm-publish/pull/73))
  - We have found that the Slack announcement does not work correctly for public channels when the `channel` parameter is given. The action has been updated to omit the default if no channel is specified, so that announcements to the default channel work correctly even if it is public.