### PR TITLE
fix: Fix action manifest validation error

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -68,7 +68,6 @@ runs:
         fi
         echo "FINAL_TEXT=$FINAL_TEXT" >> "$GITHUB_OUTPUT"
     - name: Post to a Slack channel
-      id: slack
       if: ${{ inputs.slack-webhook-url != '' && inputs.channel != '' }}
       uses: slackapi/slack-github-action@007b2c3c751a190b6f0f040e47ed024deaa72844
       with:
@@ -80,7 +79,6 @@ runs:
             "channel": "#${{ inputs.channel }}"
           }
     - name: Post to a default Slack channel
-      id: slack
       if: ${{ inputs.slack-webhook-url != '' && inputs.channel == '' }}
       uses: slackapi/slack-github-action@007b2c3c751a190b6f0f040e47ed024deaa72844
       with:


### PR DESCRIPTION
The action manifest used the id `slack` for two steps, which is not allowed. We don't reference this id anywhere, so it has been removed.