### PR TITLE
Update version and changelog with v5.0.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.0.1]
+### Fixed
+- Prevent workflow from failing if Slack announcement step fails ([#69](https://github.com/MetaMask/action-npm-publish/pull/69))
+  - Within the context of a project, the Slack announcement message that is posted after running this workflow in dry-run mode is not crucial, and thus this change ensures that the package will still be published for real if this step fails.
+
 ## [5.0.0]
 ### Changed
 - **BREAKING:** Disallow publishing packages with version 0.0.0 ([#63](https://github.com/MetaMask/action-npm-publish/pull/63))
@@ -95,7 +100,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Initial release ([#1](https://github.com/MetaMask/action-npm-publish/pull/1))
 
-[Unreleased]: https://github.com/MetaMask/action-npm-publish/compare/v5.0.0...HEAD
+[Unreleased]: https://github.com/MetaMask/action-npm-publish/compare/v5.0.1...HEAD
+[5.0.1]: https://github.com/MetaMask/action-npm-publish/compare/v5.0.0...v5.0.1
 [5.0.0]: https://github.com/MetaMask/action-npm-publish/compare/v4.0.4...v5.0.0
 [4.0.4]: https://github.com/MetaMask/action-npm-publish/compare/v4.0.3...v4.0.4
 [4.0.3]: https://github.com/MetaMask/action-npm-publish/compare/v4.0.2...v4.0.3

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "url": "https://github.com/MetaMask/action-npm-publish/issues"
   },
   "homepage": "https://github.com/MetaMask/action-npm-publish#readme",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "main": "index.js",
   "directories": {
     "test": "test"


### PR DESCRIPTION
The v5.0.1 release was back ported to the `v5.0.x` branch. This PR updates the main branch with that version bump and changelog entry.