### PR TITLE
fix: add missing configuration for non-default Slack channel messages

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -78,6 +78,10 @@ runs:
             "username": "${{ inputs.username }}",
             "channel": "#${{ inputs.channel }}"
           }
+      env:
+        SLACK_WEBHOOK_URL: ${{ inputs.slack-webhook-url }}
+        SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+      continue-on-error: true
     - name: Post to a default Slack channel
       if: ${{ inputs.slack-webhook-url != '' && inputs.channel == '' }}
       uses: slackapi/slack-github-action@007b2c3c751a190b6f0f040e47ed024deaa72844


### PR DESCRIPTION
Following recent changes it was no longer possible to use this action with a non-default Slack channel as the target for the messages.

Any attempt to use the action would fail with: `Error: Need to provide at least one botToken or webhookUrl`

This PR fixes this by re-adding the required configuration to the action.