### PR TITLE
Fix report script when publishing package with dash in organisation name

### DIFF
--- a/scripts/report.sh
+++ b/scripts/report.sh
@@ -10,10 +10,9 @@ for file in "$directory"/*.tgz; do
     if [ -f "$file" ]; then
         echo "Processing $file"
         basename=$(basename "$file")
-        name="${basename%-*}"
-        name_with_slash="${name/-//}"
-        echo "$name_with_slash"
-        pkdiff "$name_with_slash@latest" "$file" \
+        name="$(tar -O -zxf "$file" package/package.json | jq --raw-output .name)"
+        echo "$name"
+        pkdiff "$name@latest" "$file" \
             --no-exit-code \
             --no-open \
             --output "$directory/$basename.html"


### PR DESCRIPTION
After #64, the report script is broken when the package name contains a dash in the organisation part, i.e., `@my-organisation/package-name`. The name would be interpreted as `@my/organisation-package-name`, causing `pkdiff` to fail.

I've solved it by extracting the actual name from the package.