### PR TITLE
Only show packages in the dry run that need publishing

### DIFF
--- a/.github/workflows/test-monorepo.yml
+++ b/.github/workflows/test-monorepo.yml
@@ -21,7 +21,7 @@ jobs:
           cd skunkworks
           yarn install --immutable
           yarn plugin import workspace-tools
-          ../action-npm-publish/scripts/main.sh
+          PUBLISH_NPM_TAG="latest" ../action-npm-publish/scripts/main.sh
   # test that publishing is skipped when attempting to republish the latest version
   checkout_publish_skunkworks_skip:
     runs-on: ubuntu-20.04

--- a/scripts/main.sh
+++ b/scripts/main.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
-set -x
+if [[ -z $ACTIONS_RUNNER_DEBUG ]]; then
+  set -x
+fi
 set -e
 set -o pipefail
 

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
-set -e
+if [[ -z $ACTIONS_RUNNER_DEBUG ]]; then
+  set -e
+fi
 set -o pipefail
 
 export YARN_NPM_AUTH_TOKEN="${YARN_NPM_AUTH_TOKEN:-$NPM_TOKEN}"

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -11,10 +11,9 @@ if [[ "$YARN_MAJOR" -ge "3" ]]; then
   PACK_CMD="yarn pack --out /tmp/%s-%v.tgz"
   # install is handled by yarn berry pack/publish
   INSTALL_CMD=""
-  LOGIN_CMD=""
 else
   echo "Warning: Did not detect compatible yarn version. This action officially supports Yarn v3 and newer. Falling back to using npm." >&2
-  echo "//registry.npmjs.org/:_authToken=${YARN_NPM_AUTH_TOKEN}" >> $HOME/.npmrc
+  echo "//registry.npmjs.org/:_authToken=${YARN_NPM_AUTH_TOKEN}" >> "$HOME/.npmrc"
   PUBLISH_CMD="npm publish --tag $PUBLISH_NPM_TAG"
   PACK_CMD="npm pack --pack-destination=/tmp/"
   if [[ -f 'yarn.lock' ]]; then
@@ -25,7 +24,7 @@ else
 fi
 
 # "dry-run" for polyrepo
-if [[ -z $YARN_NPM_AUTH_TOKEN && ! -n "$1" ]]; then
+if [[ -z "$YARN_NPM_AUTH_TOKEN" && -z "$1" ]]; then
   echo "Notice: 'npm-token' not set. Running '$PACK_CMD'."
   $INSTALL_CMD
   $PACK_CMD
@@ -53,7 +52,7 @@ if [[ -n "$1" ]]; then
   LATEST_PACKAGE_VERSION=$(npm view "$PACKAGE_NAME" dist-tags --workspaces false --json | jq --raw-output --arg tag "$PUBLISH_NPM_TAG" '.[$tag]' || echo "")
 
   # "dry-run" for monorepo
-  if [ -z $YARN_NPM_AUTH_TOKEN && ! "$LATEST_PACKAGE_VERSION" = "$CURRENT_PACKAGE_VERSION" ]; then
+  if [[ -z "$YARN_NPM_AUTH_TOKEN" && ! "$LATEST_PACKAGE_VERSION" = "$CURRENT_PACKAGE_VERSION" ]]; then
     echo "Notice: 'npm-token' not set. Running '$PACK_CMD'."
     $PACK_CMD
     exit 0
@@ -67,4 +66,4 @@ fi
 
 $INSTALL_CMD
 $PUBLISH_CMD
-rm -f $HOME/.npmrc
+rm -f "$HOME/.npmrc"

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -24,6 +24,7 @@ else
 fi
 
 # "dry-run" for polyrepo
+echo "$1"
 if [[ -z "$YARN_NPM_AUTH_TOKEN" && -z "$1" ]]; then
   echo "Notice: 'npm-token' not set. Running '$PACK_CMD'."
   $INSTALL_CMD

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -24,7 +24,6 @@ else
 fi
 
 # "dry-run" for polyrepo
-echo "$1"
 if [[ -z "$YARN_NPM_AUTH_TOKEN" && -z "$1" ]]; then
   echo "Notice: 'npm-token' not set. Running '$PACK_CMD'."
   $INSTALL_CMD

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
 
-if [[ -z $ACTIONS_RUNNER_DEBUG ]]; then
-  set -e
-fi
+set -e
 set -o pipefail
 
 export YARN_NPM_AUTH_TOKEN="${YARN_NPM_AUTH_TOKEN:-$NPM_TOKEN}"


### PR DESCRIPTION
closes #58 

this will also ensure reports are only generated for packages that have changes