### PR TITLE
Fix report script for unpublished packages

### DIFF
--- a/scripts/report.sh
+++ b/scripts/report.sh
@@ -11,6 +11,15 @@ for file in "$directory"/*.tgz; do
         echo "Processing $file"
         basename=$(basename "$file")
         name="$(tar -O -zxf "$file" package/package.json | jq --raw-output .name)"
+
+        LATEST_PACKAGE_VERSION=$(npm view "$name" dist-tags --workspaces false --json | jq --raw-output '.latest' || echo "")
+
+        # Skip if the package is not published
+        if [ -z "$LATEST_PACKAGE_VERSION" ]; then
+            echo "Skipping $file, because $name is not published on NPM"
+            continue
+        fi
+
         echo "$name"
         pkdiff "$name@latest" "$file" \
             --no-exit-code \

--- a/scripts/report.sh
+++ b/scripts/report.sh
@@ -11,19 +11,10 @@ for file in "$directory"/*.tgz; do
         echo "Processing $file"
         basename=$(basename "$file")
         name="$(tar -O -zxf "$file" package/package.json | jq --raw-output .name)"
-
-        LATEST_PACKAGE_VERSION=$(npm view "$name" dist-tags --workspaces false --json | jq --raw-output '.latest' || echo "")
-
-        # Skip if the package is not published
-        if [ -z "$LATEST_PACKAGE_VERSION" ]; then
-            echo "Skipping $file, because $name is not published on NPM"
-            continue
-        fi
-
         echo "$name"
         pkdiff "$name@latest" "$file" \
             --no-exit-code \
             --no-open \
-            --output "$directory/$basename.html"
+            --output "$directory/$basename.html" || true
     fi
 done


### PR DESCRIPTION
`pkdiff` throws an error if the package is not published:

```
@ts-bridge/resolver
@ts-bridge/resolver@latest: downloading...
Error: Download failed: @ts-bridge/resolver@latest from registry: https://registry.npmjs.org/
    at /usr/local/lib/node_modules/pkdiff/src/compare.js:188:15
```

This makes it return with exit code 1, causing the publish to fail. As as simple workaround I've added `|| true`, which always returns exit code 0.