### PR TITLE
Disable debug output in non-debug environments

### DIFF
--- a/scripts/main.sh
+++ b/scripts/main.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-if [[ -z $ACTIONS_RUNNER_DEBUG ]]; then
+if [ "${ACTIONS_RUNNER_DEBUG}" = "true" ]; then
   set -x
 fi
 set -e


### PR DESCRIPTION
The original intent was to _only_ `set -x` when in debug environments, but instead we were setting it if `ACTIONS_RUNNER_DEBUG` was unset... so effectively all non-debug environments. This change remedies that mistake.