### PR TITLE
ci: Run CI on `ubuntu-latest` and fix tests

### DIFF
--- a/.github/workflows/test-monorepo.yml
+++ b/.github/workflows/test-monorepo.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   # test npm publish dry-run
   checkout_publish_skunkworks_dry_run:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:
@@ -24,7 +24,7 @@ jobs:
           PUBLISH_NPM_TAG="latest" ../action-npm-publish/scripts/main.sh
   # test that publishing is skipped when attempting to republish the latest version
   checkout_publish_skunkworks_skip:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Get Latest Version from npm
         id: latestrelease

--- a/.github/workflows/test-monorepo.yml
+++ b/.github/workflows/test-monorepo.yml
@@ -20,7 +20,6 @@ jobs:
         run: |
           cd skunkworks
           yarn install --immutable
-          yarn plugin import workspace-tools
           PUBLISH_NPM_TAG="latest" ../action-npm-publish/scripts/main.sh
   # test that publishing is skipped when attempting to republish the latest version
   checkout_publish_skunkworks_skip:
@@ -41,5 +40,4 @@ jobs:
         run: |
           cd skunkworks
           yarn install --immutable
-          yarn plugin import workspace-tools
           PUBLISH_NPM_TAG="latest" NPM_TOKEN="test" ../action-npm-publish/scripts/main.sh

--- a/.github/workflows/test-polyrepo.yml
+++ b/.github/workflows/test-polyrepo.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   # test npm publish dry-run
   checkout_publish_controllers_dry_run:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/test-polyrepo.yml
+++ b/.github/workflows/test-polyrepo.yml
@@ -5,14 +5,14 @@ on:
   pull_request:
 jobs:
   # test npm publish dry-run
-  checkout_publish_controllers_dry_run:
+  checkout_publish_utils_dry_run:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:
-          repository: MetaMask/controllers
-          ref: v30.0.0
-          path: controllers
+          repository: MetaMask/utils
+          ref: v11.8.1
+          path: utils
       - uses: actions/checkout@v3
         with:
           path: action-npm-publish
@@ -22,7 +22,7 @@ jobs:
       - name: Setup, Build, Publish
         shell: bash
         run: |
-          cd controllers
-          yarn setup
+          cd utils
+          yarn
           yarn build
           ../action-npm-publish/scripts/main.sh

--- a/.github/workflows/test-polyrepo.yml
+++ b/.github/workflows/test-polyrepo.yml
@@ -18,7 +18,7 @@ jobs:
           path: action-npm-publish
       - uses: actions/setup-node@v3
         with:
-          node-version: 12
+          node-version: 24
       - name: Setup, Build, Publish
         shell: bash
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - name: Setup Node.js


### PR DESCRIPTION
Jobs using `ubuntu-20.04` don't seem to run. GitHub may not provide it anymore.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Moves CI to ubuntu-latest, switches the polyrepo dry-run to MetaMask/utils with Node 24, and removes an unused yarn plugin step.
> 
> - **CI Workflows**
>   - Update runners to `ubuntu-latest` in `test.yml`, `test-monorepo.yml`, and `test-polyrepo.yml`.
> - **Polyrepo workflow (`.github/workflows/test-polyrepo.yml`)**
>   - Replace `controllers` job with `utils` dry-run (`checkout_publish_utils_dry_run`).
>   - Change repository to `MetaMask/utils@v11.8.1` and path to `utils`.
>   - Bump Node from `12` to `24` via `actions/setup-node@v3`.
>   - Update commands to `cd utils`, `yarn`, `yarn build` before publish script.
> - **Monorepo workflow (`.github/workflows/test-monorepo.yml`)**
>   - Remove `yarn plugin import workspace-tools` from setup steps.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c7a431934e21d2af222564a72c347d6faaadfcda. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->