### PR TITLE
fix: Only install `pkdiff` if no token was specified

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -36,6 +36,7 @@ runs:
         YARN_NPM_AUTH_TOKEN: ${{ inputs.npm-token }}
         PUBLISH_NPM_TAG: ${{ inputs.npm-tag }}
     - id: install-pkdiff
+      if: inputs.npm-token == ''
       shell: bash
       run: npm i -g pkdiff
     - id: generate-report


### PR DESCRIPTION
We only run `scripts/report.sh` if no NPM token is specified, but we were always installing `pkdiff` regardless, which is only used in the report script.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single conditional on a composite action step; no publish, auth, or report logic changes.
> 
> **Overview**
> Skips the global **`pkdiff`** install when an npm publish token is provided, matching the existing guard on **`generate-report`** and **`upload-artifact`**.
> 
> **`install-pkdiff`** now runs only for dry-run publishes (`inputs.npm-token == ''`), since **`pkdiff`** is only used by **`scripts/report.sh`** in that path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c1dfb29d5fe27f19e165ddfa6ba3b8a2371b283. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->