### PR TITLE
fix: Specify version for `pkdiff`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -38,7 +38,7 @@ runs:
     - id: install-pkdiff
       if: inputs.npm-token == ''
       shell: bash
-      run: npm i -g pkdiff
+      run: npm i -g pkdiff@2.0.1
     - id: generate-report
       shell: bash
       if: inputs.npm-token == ''


### PR DESCRIPTION
This locks `pkdiff` to the latest version.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line CI tooling pin with no runtime or publish-path behavior change beyond reproducible pkdiff installs.
> 
> **Overview**
> Pins the global **`pkdiff`** install in the composite action’s dry-run path from an unpinned **`npm i -g pkdiff`** to **`pkdiff@2.0.1`**, so package diff HTML reports stay on a known CLI version instead of whatever npm resolves as latest.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11d65d29bdfea486c35d40bf609ebbc7502c04aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->