### PR TITLE
feat!: Add support for NPM staged publishing

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -143,6 +143,8 @@ jobs:
           node-version: 24
       - name: Setup, build, publish
         shell: bash
+        env:
+          PUBLISH_NPM_TAG: latest
         run: |
           cd utils
           corepack enable

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -145,6 +145,7 @@ jobs:
         shell: bash
         run: |
           cd utils
+          corepack enable
           yarn install --immutable
           yarn build
           ../action-npm-publish/scripts/main.sh

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -87,18 +87,21 @@ jobs:
       - name: Checkout Snaps repository
         uses: actions/checkout@v6
         with:
-          repository: MetaMask/snaps-skunkworks
-          ref: 2befb570c72fddd577410b0193982332eed0fc41
-          path: skunkworks
+          repository: MetaMask/snaps
+          ref: 06df849a905165966c53bb1862e02420f76f6dd7
+          path: snaps
       - name: Checkout action repository
         uses: actions/checkout@v6
         with:
           path: action-npm-publish
       - name: Setup, build, publish
+        env:
+          PUBLISH_NPM_TAG: latest
         run: |
-          cd skunkworks
+          cd snaps
+          corepack enable
           yarn install --immutable
-          PUBLISH_NPM_TAG="latest" ../action-npm-publish/scripts/main.sh
+          ../action-npm-publish/scripts/main.sh
 
   test-publish-monorepo-skip:
     name: Test skipping publish of latest version (monorepo)
@@ -106,22 +109,26 @@ jobs:
     steps:
       - name: Get latest version from NPM
         id: latest-release
-        run: echo "release-version=$(npm view MetaMask/snaps-skunkworks version --workspaces=false)" >> "$GITHUB_OUTPUT"
+        run: echo "release-version=$(npm view MetaMask/snaps version --workspaces=false)" >> "$GITHUB_OUTPUT"
       - name: Checkout Snaps repository
         uses: actions/checkout@v6
         with:
-          repository: MetaMask/snaps-skunkworks
+          repository: MetaMask/snaps
           ref: v${{ steps.latest-release.outputs.release-version }}
-          path: skunkworks
+          path: snaps
       - name: Checkout action repository
         uses: actions/checkout@v6
         with:
           path: action-npm-publish
       - name: Setup, build, publish
+        env:
+          PUBLISH_NPM_TAG: latest
+          ACTIONS_ID_TOKEN_REQUEST_URL: test
         run: |
-          cd skunkworks
+          cd snaps
+          corepack enable
           yarn install --immutable
-          PUBLISH_NPM_TAG="latest" NPM_TOKEN="test" ../action-npm-publish/scripts/main.sh
+          ../action-npm-publish/scripts/main.sh
 
   test-publish-polyrepo:
     name: Test publish polyrepo

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -88,7 +88,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: MetaMask/snaps
-          ref: 06df849a905165966c53bb1862e02420f76f6dd7
+          ref: cecffa1a851a1fa5d68384c6f46ca1cf739f6d0c
           path: snaps
       - name: Checkout action repository
         uses: actions/checkout@v6

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -131,7 +131,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: MetaMask/utils
-          ref: v11.8.1
+          ref: 48e4a5a9d4d389c0e0b0a066f3ec4bb90b14e07b
           path: utils
       - name: Checkout action repository
         uses: actions/checkout@v6

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This is a GitHub action that handles publishing to NPM for a project that repres
 
 ## Requirements
 
-**This action assumes that Yarn is installed and that the package is using Yarn v3.** It may fail for other Yarn versions or other package managers.
+**This action requires Yarn 4.16.0 or higher.**
 
 If your project is configured to use the `node-modules` linker and defines a `prepack` script for any releasable packages, you will need to ensure that the file `node_modules/.yarn-state.yml` is present before this action is invoked. This file is generated automatically when installing dependencies. If you want to publish without dependencies present, you can instantiate an empty state file or restore one from a cache.
 
@@ -19,21 +19,38 @@ This action depends upon the action `slackapi/slack-github-action@007b2c3c751a19
 
 ### Quick start
 
-If you're in a hurry, take a look at the [`publish-release` workflow](https://github.com/MetaMask/metamask-module-template/blob/main/.github/workflows/publish-release.yml) from the [module template](https://github.com/MetaMask/metamask-module-template), which uses this action to publish appropriate packages whenever a release commit is merged, once in dry-run mode and once in "real" mode. (A release commit is a commit that changes the version of the primary package within the project, whether that is the sole package in the case of a polyrepo package, or the root package in the case of a monorepo.) Note that in order to use this workflow file in your project, you will need to create an `npm-publish` environment via your repository's settings and set the `NPM_TOKEN` secret within this environment to the authentication token for the MetaMask organization on `npmjs.com`.
+If you're in a hurry, take a look at the [`publish-release` workflow](https://github.com/MetaMask/metamask-module-template/blob/main/.github/workflows/publish-release.yml) from the [module template](https://github.com/MetaMask/metamask-module-template), which uses this action to publish appropriate packages whenever a release commit is merged, once in dry-run mode and once in "real" mode. (A release commit is a commit that changes the version of the primary package within the project, whether that is the sole package in the case of a polyrepo package, or the root package in the case of a monorepo.)
 
-### Publish mode
+### Publish with OIDC
 
-Add the following to a job's list of steps. This requires that you set the `NPM_TOKEN` secret in your repository's settings to an appropriate NPM authentication token:
+After the initial publish, OIDC is the only supported authentication method. Grant the job `id-token: write` permission and no `npm-token` is needed:
 
 ```yaml
-- uses: MetaMask/action-npm-publish@v2
+jobs:
+  publish:
+    permissions:
+      id-token: write
+    steps:
+      - uses: MetaMask/action-npm-publish@v4
+```
+
+This uses `--provenance` and (by default) `--staged` for publishing.
+
+### Initial publish with token
+
+NPM requires a package to exist on the registry before OIDC can be configured for it, so the very first publish must use a token:
+
+```yaml
+- uses: MetaMask/action-npm-publish@v4
   with:
     npm-token: ${{ secrets.NPM_TOKEN }}
 ```
 
+Once the package has been published at least once, the token is ignored and OIDC is used exclusively for all subsequent publishes.
+
 ### Dry run mode
 
-If you omit `npm-token`, then packages will be prepared for publishing, but no publishing will actually occur:
+If neither a token nor OIDC is available, packages will be prepared for publishing but no publishing will actually occur:
 
 ```yaml
 - uses: MetaMask/action-npm-publish@v4
@@ -79,7 +96,11 @@ You can read more about these option in the [API](#API) section below
 
 ### Inputs
 
-- **`npm-token`** _(optional)_. The auth token associated with the registry that Yarn commands will use to access and publish packages. If omitted, the action will perform a dry-run publish.
+- **`npm-token`** _(optional)_. The auth token for the NPM registry. Only used for the initial publish of a package that has not been published before, to allow OIDC to be set up for all subsequent publishes. If omitted, the action will attempt to use OIDC. If neither a token nor OIDC is available, the action will perform a dry run.
+
+- **`npm-tag`** _(optional)_. The npm tag to publish to. Defaults to `latest`.
+
+- **`staged-publish`** _(optional)_. Whether to use staged publishing when publishing via OIDC. Defaults to `true`. If set to `false`, the action will publish directly to NPM without a staging step.
 
 - **`slack-webhook-url`** _(optional)_. The incoming webhook URL associated with your Slack application for announcing releases to a Slack channel. This can be added under the "Incoming Webhooks" section of your Slack app configuration.
 

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,9 @@
 name: 'Publish to npm'
 description: 'Publish the release to npm'
 inputs:
+  npm-token:
+    description: 'The token used for npm publishing. Only used for the initial publish of a package, to allow for OIDC to be set up for subsequent publishes. If not provided, the action will attempt to use OIDC for authentication.'
+    required: false
   npm-tag:
     description: 'The npm tag to publish to. Defaults to "latest".'
     required: false
@@ -34,6 +37,7 @@ runs:
       shell: bash
       run: ${{ github.action_path }}/scripts/main.sh
       env:
+        YARN_NPM_AUTH_TOKEN: ${{ inputs.npm-token }}
         PUBLISH_NPM_TAG: ${{ inputs.npm-tag }}
         STAGED_PUBLISH: ${{ inputs.staged-publish }}
     - id: install-pkdiff

--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,10 @@ inputs:
     description: 'The npm tag to publish to. Defaults to "latest".'
     required: false
     default: 'latest'
+  npm-staged-publish:
+    description: 'Whether to use staged publishing using an OIDC token. Mutually exclusive with "npm-token".'
+    required: false
+    default: 'false'
   slack-webhook-url:
     description: 'Slack Webhook URL'
     required: false
@@ -35,6 +39,7 @@ runs:
       env:
         YARN_NPM_AUTH_TOKEN: ${{ inputs.npm-token }}
         PUBLISH_NPM_TAG: ${{ inputs.npm-tag }}
+        STAGED_PUBLISH: ${{ inputs.npm-staged-publish }}
     - id: install-pkdiff
       if: inputs.npm-token == ''
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -1,17 +1,14 @@
 name: 'Publish to npm'
 description: 'Publish the release to npm'
 inputs:
-  npm-token:
-    description: 'The token used for npm publishing. If omitted the action will perform a dry run npm publish.'
-    required: false
   npm-tag:
     description: 'The npm tag to publish to. Defaults to "latest".'
     required: false
     default: 'latest'
-  npm-staged-publish:
-    description: 'Whether to use staged publishing using an OIDC token. Mutually exclusive with "npm-token".'
+  staged-publish:
+    description: 'Whether to use staged publishing. Defaults to "true". If set to "false", the action will publish directly to NPM without a staging step.'
     required: false
-    default: 'false'
+    default: 'true'
   slack-webhook-url:
     description: 'Slack Webhook URL'
     required: false
@@ -37,9 +34,8 @@ runs:
       shell: bash
       run: ${{ github.action_path }}/scripts/main.sh
       env:
-        YARN_NPM_AUTH_TOKEN: ${{ inputs.npm-token }}
         PUBLISH_NPM_TAG: ${{ inputs.npm-tag }}
-        STAGED_PUBLISH: ${{ inputs.npm-staged-publish }}
+        STAGED_PUBLISH: ${{ inputs.staged-publish }}
     - id: install-pkdiff
       if: inputs.npm-token == ''
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -30,22 +30,22 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - id: Publish
+    - id: publish
       shell: bash
       run: ${{ github.action_path }}/scripts/main.sh
       env:
         PUBLISH_NPM_TAG: ${{ inputs.npm-tag }}
         STAGED_PUBLISH: ${{ inputs.staged-publish }}
     - id: install-pkdiff
-      if: inputs.npm-token == ''
+      if: steps.publish.outputs.dry-run == 'true'
       shell: bash
       run: npm i -g pkdiff@2.0.1
     - id: generate-report
       shell: bash
-      if: inputs.npm-token == ''
+      if: steps.publish.outputs.dry-run == 'true'
       run: ${{ github.action_path }}/scripts/report.sh
     - id: upload-artifact
-      if: inputs.npm-token == ''
+      if: steps.publish.outputs.dry-run == 'true'
       uses: actions/upload-artifact@v4
       with:
         path: |

--- a/scripts/main.sh
+++ b/scripts/main.sh
@@ -9,10 +9,10 @@ set -o pipefail
 script_path=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
 
 if [[ "$(jq 'has("workspaces")' package.json)" = "true" ]]; then
-  echo "Notice: workspaces detected. Treating as monorepo."
+  echo "Notice: Workspaces detected. Treating as monorepo."
   yarn workspaces foreach --all --no-private --verbose exec "$script_path/publish.sh true"
   exit 0
 fi
 
-echo "Notice: no workspaces detected. Treating as polyrepo."
+echo "Notice: No workspaces detected. Treating as polyrepo."
 "${script_path}"/publish.sh

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -105,7 +105,7 @@ main() {
   configure_publish
 
   IS_MONOREPO="$1"
-  if [[ -n "$IS_MONOREPO" ]]; then
+  if [[ "$IS_MONOREPO" = "true" ]]; then
     publish_monorepo
   else
     publish_polyrepo

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -3,47 +3,73 @@
 set -e
 set -o pipefail
 
-YARN_MAJOR="$(yarn --version | sed 's/\..*//' || true)"
-if [[ "$YARN_MAJOR" -lt "3" ]]; then
-  echo "Notice: Unsupported Yarn version: $YARN_MAJOR. Please upgrade to Yarn 3 or later."
+if [ "$RUNNER_DEBUG" = "1" ]; then
+  set -x
+fi
+
+IFS='.' read -r YARN_MAJOR YARN_MINOR _ <<< "$(yarn --version)"
+
+# TODO: Set this to the right version when Yarn releases a new version with the
+# `--staged` flag for `yarn npm publish`.
+if [[ "$YARN_MAJOR" -lt 4 || ( "$YARN_MAJOR" -eq 4 && "$YARN_MINOR" -lt 15 ) ]]; then
+  echo "::error::Yarn version 4.15.0 or higher is required. Detected version: $(yarn --version)."
+  exit 1
+fi
+
+if [[ -z "$PUBLISH_NPM_TAG" ]]; then
+  echo "::error::'npm-tag' not set."
   exit 1
 fi
 
 PACK_CMD="yarn pack --out /tmp/%s-%v.tgz"
 
-# https://docs.npmjs.com/staged-publishing
-if [[ "$STAGED_PUBLISH" = "true" ]]; then
-  PUBLISH_CMD="yarn npm publish --tag $PUBLISH_NPM_TAG --staged --provenance"
-else
-  PUBLISH_CMD="yarn npm publish --tag $PUBLISH_NPM_TAG --provenance"
-fi
+# Get the package name and the latest published version for the specified tag,
+# if it exists.
+PACKAGE_NAME=$(jq --raw-output .name package.json)
+LATEST_PACKAGE_VERSION=$(npm view "$PACKAGE_NAME" dist-tags --workspaces false --json 2>/dev/null | jq --raw-output --arg tag "$PUBLISH_NPM_TAG" '.[$tag]' || echo "")
 
-# Perform a dry run if OIDC is not available.
-if [[ -z "$ACTIONS_ID_TOKEN_REQUEST_URL" ]]; then
-  echo "Notice: OIDC is not available. Performing a dry run."
-  DRY_RUN="true"
-else
+# Determine the publish command and whether to perform a dry run. It works as
+# follows:
+# 1. If a token is provided, and the package has not been published before, use
+# the token for the initial publish.
+# 2. If a token is provided, but the package has already been published, ignore
+# the token and fall back to OIDC (if available) for subsequent publish.
+# 3. If no token is provided, use OIDC if available.
+# 4. If neither a token nor OIDC is available, perform a dry run.
+if [[ -n "$YARN_NPM_AUTH_TOKEN" && -z "$LATEST_PACKAGE_VERSION" ]]; then
+  echo "Notice: Package not yet published. Using token for initial publish."
+  PUBLISH_CMD="yarn npm publish --tag $PUBLISH_NPM_TAG"
   DRY_RUN="false"
+elif [[ -n "$YARN_NPM_AUTH_TOKEN" ]]; then
+  echo "Notice: Package already published; ignoring token and falling back to OIDC."
 fi
 
-[[ -n "$GITHUB_OUTPUT" ]] && echo "dry-run=$DRY_RUN" >> "$GITHUB_OUTPUT"
+# Dry run will be set to false if a token is provided and the package has not
+# been published before. Otherwise, we check for OIDC availability and set the
+# publish command accordingly.
+if [[ -z "$DRY_RUN" ]]; then
+  # No token used - use OIDC if available.
+  if [[ -n "$ACTIONS_ID_TOKEN_REQUEST_URL" ]]; then
+    if [[ "$STAGED_PUBLISH" = "true" ]]; then
+      PUBLISH_CMD="yarn npm publish --tag $PUBLISH_NPM_TAG --staged --provenance"
+    else
+      PUBLISH_CMD="yarn npm publish --tag $PUBLISH_NPM_TAG --provenance"
+    fi
+    DRY_RUN="false"
+  else
+    echo "Notice: OIDC is not available. Performing a dry run."
+    DRY_RUN="true"
+  fi
+fi
 
-IS_MONOREPO="$1"
+# Export the "dry-run" status for use in subsequent steps, if GITHUB_OUTPUT is
+# available.
+[[ -n "$GITHUB_OUTPUT" ]] && echo "dry-run=$DRY_RUN" >> "$GITHUB_OUTPUT"
 
 # "dry-run" for polyrepo
 if [[ "$DRY_RUN" = "true" && -z "$IS_MONOREPO" ]]; then
-  $INSTALL_CMD
   $PACK_CMD
   exit 0
-fi
-
-if [ "${RUNNER_DEBUG}" = "1" ]; then
-  set -x
-fi
-
-if [[ -z "$PUBLISH_NPM_TAG" ]]; then
-  echo "Notice: 'npm-tag' not set."
-  exit 1
 fi
 
 CURRENT_PACKAGE_VERSION=$(jq --raw-output .version package.json)
@@ -53,13 +79,11 @@ if [[ "$CURRENT_PACKAGE_VERSION" = "0.0.0" ]]; then
   exit 0
 fi
 
+IS_MONOREPO="$1"
+
 # check param, if it's set (monorepo) we check if it's published before proceeding
 if [[ -n "$IS_MONOREPO" ]]; then
-  # check if module is published
-  PACKAGE_NAME=$(jq --raw-output .name package.json)
-  LATEST_PACKAGE_VERSION=$(npm view "$PACKAGE_NAME" dist-tags --workspaces false --json | jq --raw-output --arg tag "$PUBLISH_NPM_TAG" '.[$tag]' || echo "")
-
-  # "dry-run" for monorepo
+  # "dry-run" for monorepo.
   if [[ "$DRY_RUN" = "true" && ! "$LATEST_PACKAGE_VERSION" = "$CURRENT_PACKAGE_VERSION" ]]; then
     echo "Notice: OIDC is not available. Running '$PACK_CMD'."
     $PACK_CMD

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -74,7 +74,9 @@ configure_publish() {
 
   # Export the "dry-run" status for use in subsequent steps, if GITHUB_OUTPUT is
   # available.
-  [[ -n "$GITHUB_OUTPUT" ]] && echo "dry-run=$DRY_RUN" >> "$GITHUB_OUTPUT"
+  if [[ -n "$GITHUB_OUTPUT" ]]; then
+    echo "dry-run=$DRY_RUN" >> "$GITHUB_OUTPUT"
+  fi
 }
 
 publish_polyrepo() {

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -87,17 +87,16 @@ publish_polyrepo() {
 }
 
 publish_monorepo() {
-  if [[ "$DRY_RUN" = "true" && ! "$LATEST_PACKAGE_VERSION" = "$CURRENT_PACKAGE_VERSION" ]]; then
-    $PACK_CMD
-    exit 0
-  fi
-
   if [ "$LATEST_PACKAGE_VERSION" = "$CURRENT_PACKAGE_VERSION" ]; then
     echo "Notice: This module is already published at $CURRENT_PACKAGE_VERSION. Aborting publish."
     exit 0
   fi
 
-  $PUBLISH_CMD
+  if [[ "$DRY_RUN" = "true" ]]; then
+    $PACK_CMD
+  else
+    $PUBLISH_CMD
+  fi
 }
 
 main() {

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -67,6 +67,8 @@ fi
 # available.
 [[ -n "$GITHUB_OUTPUT" ]] && echo "dry-run=$DRY_RUN" >> "$GITHUB_OUTPUT"
 
+IS_MONOREPO="$1"
+
 # "dry-run" for polyrepo
 if [[ "$DRY_RUN" = "true" && -z "$IS_MONOREPO" ]]; then
   $PACK_CMD
@@ -79,8 +81,6 @@ if [[ "$CURRENT_PACKAGE_VERSION" = "0.0.0" ]]; then
   echo "Notice: Invalid version: $CURRENT_PACKAGE_VERSION. Aborting publish."
   exit 0
 fi
-
-IS_MONOREPO="$1"
 
 # check param, if it's set (monorepo) we check if it's published before proceeding
 if [[ -n "$IS_MONOREPO" ]]; then

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -35,6 +35,8 @@ else
   DRY_RUN="false"
 fi
 
+[[ -n "$GITHUB_OUTPUT" ]] && echo "dry-run=$DRY_RUN" >> "$GITHUB_OUTPUT"
+
 IS_MONOREPO="$1"
 
 # "dry-run" for polyrepo

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -3,8 +3,6 @@
 set -e
 set -o pipefail
 
-export YARN_NPM_AUTH_TOKEN="${YARN_NPM_AUTH_TOKEN:-$NPM_TOKEN}"
-
 YARN_MAJOR="$(yarn --version | sed 's/\..*//' || true)"
 if [[ "$YARN_MAJOR" -ge "3" ]]; then
   PUBLISH_CMD="yarn npm publish --tag $PUBLISH_NPM_TAG"
@@ -13,7 +11,6 @@ if [[ "$YARN_MAJOR" -ge "3" ]]; then
   INSTALL_CMD=""
 else
   echo "Warning: Did not detect compatible yarn version. This action officially supports Yarn v3 and newer. Falling back to using npm." >&2
-  echo "//registry.npmjs.org/:_authToken=${YARN_NPM_AUTH_TOKEN}" >> "$HOME/.npmrc"
   PUBLISH_CMD="npm publish --tag $PUBLISH_NPM_TAG"
   PACK_CMD="npm pack --pack-destination=/tmp/"
   if [[ -f 'yarn.lock' ]]; then
@@ -30,9 +27,9 @@ if [[ "$STAGED_PUBLISH" = "true" ]]; then
   PUBLISH_CMD="npm stage publish --tag $PUBLISH_NPM_TAG --provenance"
 fi
 
-# Perform a dry run if no auth token is provided and it's not a staged publish.
-if [[ -z "$YARN_NPM_AUTH_TOKEN" && "$STAGED_PUBLISH" != "true" ]]; then
-  echo "Notice: 'npm-token' not set, and 'staged-publish' is not enabled. Performing a dry run."
+# Perform a dry run if OIDC is not available.
+if [[ -z "$ACTIONS_ID_TOKEN_REQUEST_URL" ]]; then
+  echo "Notice: OIDC is not available. Performing a dry run."
   DRY_RUN="true"
 else
   DRY_RUN="false"
@@ -71,7 +68,7 @@ if [[ -n "$IS_MONOREPO" ]]; then
 
   # "dry-run" for monorepo
   if [[ "$DRY_RUN" = "true" && ! "$LATEST_PACKAGE_VERSION" = "$CURRENT_PACKAGE_VERSION" ]]; then
-    echo "Notice: 'npm-token' not set. Running '$PACK_CMD'."
+    echo "Notice: OIDC is not available. Running '$PACK_CMD'."
     $PACK_CMD
     exit 0
   fi
@@ -84,4 +81,3 @@ fi
 
 $INSTALL_CMD
 $PUBLISH_CMD
-rm -f "$HOME/.npmrc"

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -4,27 +4,18 @@ set -e
 set -o pipefail
 
 YARN_MAJOR="$(yarn --version | sed 's/\..*//' || true)"
-if [[ "$YARN_MAJOR" -ge "3" ]]; then
-  PUBLISH_CMD="yarn npm publish --tag $PUBLISH_NPM_TAG"
-  PACK_CMD="yarn pack --out /tmp/%s-%v.tgz"
-  # install is handled by yarn berry pack/publish
-  INSTALL_CMD=""
-else
-  echo "Warning: Did not detect compatible yarn version. This action officially supports Yarn v3 and newer. Falling back to using npm." >&2
-  PUBLISH_CMD="npm publish --tag $PUBLISH_NPM_TAG"
-  PACK_CMD="npm pack --pack-destination=/tmp/"
-  if [[ -f 'yarn.lock' ]]; then
-    INSTALL_CMD="yarn install --frozen-lockfile"
-  else
-    INSTALL_CMD="npm ci"
-  fi
+if [[ "$YARN_MAJOR" -lt "3" ]]; then
+  echo "Notice: Unsupported Yarn version: $YARN_MAJOR. Please upgrade to Yarn 3 or later."
+  exit 1
 fi
+
+PACK_CMD="yarn pack --out /tmp/%s-%v.tgz"
 
 # https://docs.npmjs.com/staged-publishing
 if [[ "$STAGED_PUBLISH" = "true" ]]; then
-  # Yarn does not support staged publishing (yet), so we use NPM for that even
-  # if Yarn is the default package manager.
-  PUBLISH_CMD="npm stage publish --tag $PUBLISH_NPM_TAG --provenance"
+  PUBLISH_CMD="yarn npm publish --tag $PUBLISH_NPM_TAG --staged --provenance"
+else
+  PUBLISH_CMD="yarn npm publish --tag $PUBLISH_NPM_TAG --provenance"
 fi
 
 # Perform a dry run if OIDC is not available.
@@ -58,7 +49,7 @@ fi
 CURRENT_PACKAGE_VERSION=$(jq --raw-output .version package.json)
 
 if [[ "$CURRENT_PACKAGE_VERSION" = "0.0.0" ]]; then
-  echo "Notice: Invalid version: $CURRENT_PACKAGE_VERSION. aborting publish."
+  echo "Notice: Invalid version: $CURRENT_PACKAGE_VERSION. Aborting publish."
   exit 0
 fi
 
@@ -81,5 +72,4 @@ if [[ -n "$IS_MONOREPO" ]]; then
   fi
 fi
 
-$INSTALL_CMD
 $PUBLISH_CMD

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -10,8 +10,6 @@ fi
 check_requirements() {
   IFS='.' read -r YARN_MAJOR YARN_MINOR _ <<< "$(yarn --version)"
 
-  # TODO: Set this to the right version when Yarn releases a new version with the
-  # `--staged` flag for `yarn npm publish`.
   if [[ "$YARN_MAJOR" -lt 4 || ( "$YARN_MAJOR" -eq 4 && "$YARN_MINOR" -lt 16 ) ]]; then
     echo "::error::Yarn version 4.16.0 or higher is required. Detected version: $(yarn --version)."
     exit 1

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -23,11 +23,25 @@ else
   fi
 fi
 
+# https://docs.npmjs.com/staged-publishing
+if [[ "$STAGED_PUBLISH" = "true" ]]; then
+  # Yarn does not support staged publishing (yet), so we use NPM for that even
+  # if Yarn is the default package manager.
+  PUBLISH_CMD="npm stage publish --tag $PUBLISH_NPM_TAG --provenance"
+fi
+
+# Perform a dry run if no auth token is provided and it's not a staged publish.
+if [[ -z "$YARN_NPM_AUTH_TOKEN" && "$STAGED_PUBLISH" != "true" ]]; then
+  echo "Notice: 'npm-token' not set, and 'staged-publish' is not enabled. Performing a dry run."
+  DRY_RUN="true"
+else
+  DRY_RUN="false"
+fi
+
 IS_MONOREPO="$1"
 
 # "dry-run" for polyrepo
-if [[ -z "$YARN_NPM_AUTH_TOKEN" && -z "$IS_MONOREPO" ]]; then
-  echo "Notice: 'npm-token' not set. Running '$PACK_CMD'."
+if [[ "$DRY_RUN" = "true" && -z "$IS_MONOREPO" ]]; then
   $INSTALL_CMD
   $PACK_CMD
   exit 0
@@ -37,7 +51,7 @@ if [ "${RUNNER_DEBUG}" = "1" ]; then
   set -x
 fi
 
-if [[ -z $PUBLISH_NPM_TAG ]]; then
+if [[ -z "$PUBLISH_NPM_TAG" ]]; then
   echo "Notice: 'npm-tag' not set."
   exit 1
 fi
@@ -56,14 +70,14 @@ if [[ -n "$IS_MONOREPO" ]]; then
   LATEST_PACKAGE_VERSION=$(npm view "$PACKAGE_NAME" dist-tags --workspaces false --json | jq --raw-output --arg tag "$PUBLISH_NPM_TAG" '.[$tag]' || echo "")
 
   # "dry-run" for monorepo
-  if [[ -z "$YARN_NPM_AUTH_TOKEN" && ! "$LATEST_PACKAGE_VERSION" = "$CURRENT_PACKAGE_VERSION" ]]; then
+  if [[ "$DRY_RUN" = "true" && ! "$LATEST_PACKAGE_VERSION" = "$CURRENT_PACKAGE_VERSION" ]]; then
     echo "Notice: 'npm-token' not set. Running '$PACK_CMD'."
     $PACK_CMD
     exit 0
   fi
 
   if [ "$LATEST_PACKAGE_VERSION" = "$CURRENT_PACKAGE_VERSION" ]; then
-    echo "Notice: This module is already published at $CURRENT_PACKAGE_VERSION. aborting publish."
+    echo "Notice: This module is already published at $CURRENT_PACKAGE_VERSION. Aborting publish."
     exit 0
   fi
 fi

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -41,7 +41,7 @@ if [[ -n "$YARN_NPM_AUTH_TOKEN" && -z "$LATEST_PACKAGE_VERSION" ]]; then
   PUBLISH_CMD="yarn npm publish --tag $PUBLISH_NPM_TAG"
   DRY_RUN="false"
 elif [[ -n "$YARN_NPM_AUTH_TOKEN" ]]; then
-  echo "Notice: Package already published; ignoring token and falling back to OIDC."
+  echo "Notice: Package already published. Ignoring token and falling back to OIDC."
 fi
 
 # Dry run will be set to false if a token is provided and the package has not

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -7,86 +7,87 @@ if [ "$RUNNER_DEBUG" = "1" ]; then
   set -x
 fi
 
-IFS='.' read -r YARN_MAJOR YARN_MINOR _ <<< "$(yarn --version)"
+check_requirements() {
+  IFS='.' read -r YARN_MAJOR YARN_MINOR _ <<< "$(yarn --version)"
 
-# TODO: Set this to the right version when Yarn releases a new version with the
-# `--staged` flag for `yarn npm publish`.
-if [[ "$YARN_MAJOR" -lt 4 || ( "$YARN_MAJOR" -eq 4 && "$YARN_MINOR" -lt 15 ) ]]; then
-  echo "::error::Yarn version 4.15.0 or higher is required. Detected version: $(yarn --version)."
-  exit 1
-fi
-
-if [[ -z "$PUBLISH_NPM_TAG" ]]; then
-  echo "::error::'npm-tag' not set."
-  exit 1
-fi
-
-PACK_CMD="yarn pack --out /tmp/%s-%v.tgz"
-
-# Get the package name and the latest published version for the specified tag,
-# if it exists. Note that we're `cd`ing into /tmp before running `npm view` to
-# avoid any issues with Corepack detecting Yarn.
-PACKAGE_NAME=$(jq --raw-output .name package.json)
-LATEST_PACKAGE_VERSION=$(cd /tmp && npm view "$PACKAGE_NAME" dist-tags --workspaces false --json 2>/dev/null | jq --raw-output --arg tag "$PUBLISH_NPM_TAG" '.[$tag] // empty' || echo "")
-
-# Determine the publish command and whether to perform a dry run. It works as
-# follows:
-# 1. If a token is provided, and the package has not been published before, use
-# the token for the initial publish.
-# 2. If a token is provided, but the package has already been published, ignore
-# the token and fall back to OIDC (if available) for subsequent publish.
-# 3. If no token is provided, use OIDC if available.
-# 4. If neither a token nor OIDC is available, perform a dry run.
-if [[ -n "$YARN_NPM_AUTH_TOKEN" && -z "$LATEST_PACKAGE_VERSION" ]]; then
-  echo "Notice: Package not yet published. Using token for initial publish."
-  PUBLISH_CMD="yarn npm publish --tag $PUBLISH_NPM_TAG"
-  DRY_RUN="false"
-elif [[ -n "$YARN_NPM_AUTH_TOKEN" ]]; then
-  echo "Notice: Package already published. Ignoring token and falling back to OIDC."
-fi
-
-# Dry run will be set to false if a token is provided and the package has not
-# been published before. Otherwise, we check for OIDC availability and set the
-# publish command accordingly.
-if [[ -z "$DRY_RUN" ]]; then
-  # No token used - use OIDC if available.
-  if [[ -n "$ACTIONS_ID_TOKEN_REQUEST_URL" ]]; then
-    if [[ "$STAGED_PUBLISH" = "true" ]]; then
-      PUBLISH_CMD="yarn npm publish --tag $PUBLISH_NPM_TAG --staged --provenance"
-    else
-      PUBLISH_CMD="yarn npm publish --tag $PUBLISH_NPM_TAG --provenance"
-    fi
-    DRY_RUN="false"
-  else
-    echo "Notice: OIDC is not available. Performing a dry run."
-    DRY_RUN="true"
+  # TODO: Set this to the right version when Yarn releases a new version with the
+  # `--staged` flag for `yarn npm publish`.
+  if [[ "$YARN_MAJOR" -lt 4 || ( "$YARN_MAJOR" -eq 4 && "$YARN_MINOR" -lt 15 ) ]]; then
+    echo "::error::Yarn version 4.15.0 or higher is required. Detected version: $(yarn --version)."
+    exit 1
   fi
-fi
 
-# Export the "dry-run" status for use in subsequent steps, if GITHUB_OUTPUT is
-# available.
-[[ -n "$GITHUB_OUTPUT" ]] && echo "dry-run=$DRY_RUN" >> "$GITHUB_OUTPUT"
+  if [[ -z "$PUBLISH_NPM_TAG" ]]; then
+    echo "::error::'npm-tag' not set."
+    exit 1
+  fi
 
-IS_MONOREPO="$1"
+  CURRENT_PACKAGE_VERSION=$(jq --raw-output .version package.json)
+  if [[ "$CURRENT_PACKAGE_VERSION" = "0.0.0" ]]; then
+    echo "Notice: Invalid version: $CURRENT_PACKAGE_VERSION. Aborting publish."
+    exit 0
+  fi
+}
 
-# "dry-run" for polyrepo
-if [[ "$DRY_RUN" = "true" && -z "$IS_MONOREPO" ]]; then
-  $PACK_CMD
-  exit 0
-fi
+get_package_info() {
+  PACKAGE_NAME=$(jq --raw-output .name package.json)
 
-CURRENT_PACKAGE_VERSION=$(jq --raw-output .version package.json)
+  # Get the latest published version for the specified tag, if it exists. Note
+  # that we're `cd`ing into /tmp before running `npm view` to avoid any issues
+  # with Corepack detecting Yarn.
+  LATEST_PACKAGE_VERSION=$(cd /tmp && npm view "$PACKAGE_NAME" dist-tags --workspaces false --json 2>/dev/null | jq --raw-output --arg tag "$PUBLISH_NPM_TAG" '.[$tag] // empty' || echo "")
+}
 
-if [[ "$CURRENT_PACKAGE_VERSION" = "0.0.0" ]]; then
-  echo "Notice: Invalid version: $CURRENT_PACKAGE_VERSION. Aborting publish."
-  exit 0
-fi
+configure_publish() {
+  PACK_CMD="yarn pack --out /tmp/%s-%v.tgz"
 
-# check param, if it's set (monorepo) we check if it's published before proceeding
-if [[ -n "$IS_MONOREPO" ]]; then
-  # "dry-run" for monorepo.
+  # Determine the publish command and whether to perform a dry run. It works
+  # as follows:
+  # 1. If a token is provided, and the package has not been published before,
+  #    use the token for the initial publish.
+  # 2. If a token is provided, but the package has already been published,
+  #    ignore the token and fall back to OIDC (if available) for subsequent
+  #    publish.
+  # 3. If no token is provided, use OIDC if available.
+  # 4. If neither a token nor OIDC is available, perform a dry run.
+  if [[ -n "$YARN_NPM_AUTH_TOKEN" && -z "$LATEST_PACKAGE_VERSION" ]]; then
+    echo "Notice: Package not yet published. Using token for initial publish."
+    PUBLISH_CMD="yarn npm publish --tag $PUBLISH_NPM_TAG"
+    DRY_RUN="false"
+  elif [[ -n "$YARN_NPM_AUTH_TOKEN" ]]; then
+    echo "Notice: Package already published. Ignoring token and falling back to OIDC."
+  fi
+
+  if [[ -z "$DRY_RUN" ]]; then
+    if [[ -n "$ACTIONS_ID_TOKEN_REQUEST_URL" ]]; then
+      if [[ "$STAGED_PUBLISH" = "true" ]]; then
+        PUBLISH_CMD="yarn npm publish --tag $PUBLISH_NPM_TAG --staged --provenance"
+      else
+        PUBLISH_CMD="yarn npm publish --tag $PUBLISH_NPM_TAG --provenance"
+      fi
+      DRY_RUN="false"
+    else
+      echo "Notice: OIDC is not available. Performing a dry run."
+      DRY_RUN="true"
+    fi
+  fi
+
+  # Export the "dry-run" status for use in subsequent steps, if GITHUB_OUTPUT is
+  # available.
+  [[ -n "$GITHUB_OUTPUT" ]] && echo "dry-run=$DRY_RUN" >> "$GITHUB_OUTPUT"
+}
+
+publish_polyrepo() {
+  if [[ "$DRY_RUN" = "true" ]]; then
+    $PACK_CMD
+    exit 0
+  fi
+
+  $PUBLISH_CMD
+}
+
+publish_monorepo() {
   if [[ "$DRY_RUN" = "true" && ! "$LATEST_PACKAGE_VERSION" = "$CURRENT_PACKAGE_VERSION" ]]; then
-    echo "Notice: OIDC is not available. Running '$PACK_CMD'."
     $PACK_CMD
     exit 0
   fi
@@ -95,6 +96,21 @@ if [[ -n "$IS_MONOREPO" ]]; then
     echo "Notice: This module is already published at $CURRENT_PACKAGE_VERSION. Aborting publish."
     exit 0
   fi
-fi
 
-$PUBLISH_CMD
+  $PUBLISH_CMD
+}
+
+main() {
+  check_requirements
+  get_package_info
+  configure_publish
+
+  IS_MONOREPO="$1"
+  if [[ -n "$IS_MONOREPO" ]]; then
+    publish_monorepo
+  else
+    publish_polyrepo
+  fi
+}
+
+main "$@"

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -32,10 +32,10 @@ check_requirements() {
 get_package_info() {
   PACKAGE_NAME=$(jq --raw-output .name package.json)
 
-  # Get the latest published version for the specified tag, if it exists. Note
-  # that we're `cd`ing into /tmp before running `npm view` to avoid any issues
-  # with Corepack detecting Yarn.
-  LATEST_PACKAGE_VERSION=$(cd /tmp && npm view "$PACKAGE_NAME" dist-tags --workspaces false --json 2>/dev/null | jq --raw-output --arg tag "$PUBLISH_NPM_TAG" '.[$tag] // empty' || echo "")
+  # Check whether the package exists on npm at all. Note that we're `cd`ing
+  # into /tmp before running `npm view` to avoid any issues with Corepack
+  # detecting Yarn.
+  PACKAGE_EXISTS=$(cd /tmp && npm view "$PACKAGE_NAME" version --workspaces false --json 2>/dev/null | jq --raw-output '. // empty' || echo "")
 }
 
 configure_publish() {
@@ -50,7 +50,7 @@ configure_publish() {
   #    publish.
   # 3. If no token is provided, use OIDC if available.
   # 4. If neither a token nor OIDC is available, perform a dry run.
-  if [[ -n "$YARN_NPM_AUTH_TOKEN" && -z "$LATEST_PACKAGE_VERSION" ]]; then
+  if [[ -n "$YARN_NPM_AUTH_TOKEN" && -z "$PACKAGE_EXISTS" ]]; then
     echo "Notice: Package not yet published. Using token for initial publish."
     PUBLISH_CMD="yarn npm publish --tag $PUBLISH_NPM_TAG"
     DRY_RUN="false"
@@ -89,6 +89,11 @@ publish_polyrepo() {
 }
 
 publish_monorepo() {
+  # Get the published version for the specified tag, if it exists. Note that
+  # we're `cd`ing into /tmp before running `npm view` to avoid any issues with
+  # Corepack detecting Yarn.
+  LATEST_PACKAGE_VERSION=$(cd /tmp && npm view "$PACKAGE_NAME" dist-tags --workspaces false --json 2>/dev/null | jq --raw-output --arg tag "$PUBLISH_NPM_TAG" '.[$tag] // empty' || echo "")
+
   if [ "$LATEST_PACKAGE_VERSION" = "$CURRENT_PACKAGE_VERSION" ]; then
     echo "Notice: This module is already published at $CURRENT_PACKAGE_VERSION. Aborting publish."
     exit 0

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -35,7 +35,7 @@ get_package_info() {
   # Check whether the package exists on npm at all. Note that we're `cd`ing
   # into /tmp before running `npm view` to avoid any issues with Corepack
   # detecting Yarn.
-  PACKAGE_EXISTS=$(cd /tmp && npm view "$PACKAGE_NAME" version --workspaces false --json 2>/dev/null | jq --raw-output '. // empty' || echo "")
+  PUBLISHED_PACKAGE_VERSION=$(cd /tmp && npm view "$PACKAGE_NAME" --workspaces false --json 2>/dev/null | jq --raw-output '.version // empty' || echo "")
 }
 
 configure_publish() {
@@ -50,7 +50,7 @@ configure_publish() {
   #    publish.
   # 3. If no token is provided, use OIDC if available.
   # 4. If neither a token nor OIDC is available, perform a dry run.
-  if [[ -n "$YARN_NPM_AUTH_TOKEN" && -z "$PACKAGE_EXISTS" ]]; then
+  if [[ -n "$YARN_NPM_AUTH_TOKEN" && -z "$PUBLISHED_PACKAGE_VERSION" ]]; then
     echo "Notice: Package not yet published. Using token for initial publish."
     PUBLISH_CMD="yarn npm publish --tag $PUBLISH_NPM_TAG"
     DRY_RUN="false"

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -24,9 +24,10 @@ fi
 PACK_CMD="yarn pack --out /tmp/%s-%v.tgz"
 
 # Get the package name and the latest published version for the specified tag,
-# if it exists.
+# if it exists. Note that we're `cd`ing into /tmp before running `npm view` to
+# avoid any issues with Corepack detecting Yarn.
 PACKAGE_NAME=$(jq --raw-output .name package.json)
-LATEST_PACKAGE_VERSION=$(npm view "$PACKAGE_NAME" dist-tags --workspaces false --json 2>/dev/null | jq --raw-output --arg tag "$PUBLISH_NPM_TAG" '.[$tag]' || echo "")
+LATEST_PACKAGE_VERSION=$(cd /tmp && npm view "$PACKAGE_NAME" dist-tags --workspaces false --json 2>/dev/null | jq --raw-output --arg tag "$PUBLISH_NPM_TAG" '.[$tag] // empty' || echo "")
 
 # Determine the publish command and whether to perform a dry run. It works as
 # follows:

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -12,8 +12,8 @@ check_requirements() {
 
   # TODO: Set this to the right version when Yarn releases a new version with the
   # `--staged` flag for `yarn npm publish`.
-  if [[ "$YARN_MAJOR" -lt 4 || ( "$YARN_MAJOR" -eq 4 && "$YARN_MINOR" -lt 15 ) ]]; then
-    echo "::error::Yarn version 4.15.0 or higher is required. Detected version: $(yarn --version)."
+  if [[ "$YARN_MAJOR" -lt 4 || ( "$YARN_MAJOR" -eq 4 && "$YARN_MINOR" -lt 16 ) ]]; then
+    echo "::error::Yarn version 4.16.0 or higher is required. Detected version: $(yarn --version)."
     exit 1
   fi
 

--- a/test/index.js
+++ b/test/index.js
@@ -41,7 +41,7 @@ test('correct version should appear in dry-run output', async (tapzero) => {
   });
 });
 
-test('throws an error when OIDC token is invalid', async (t) => {
+test('throws an error when OIDC token is invalid', async (tapzero) => {
   await new Promise((resolve, reject) => {
     exec(
       `ACTIONS_ID_TOKEN_REQUEST_URL=${FAKE} ACTIONS_ID_TOKEN_REQUEST_TOKEN=${FAKE} STAGED_PUBLISH=true ./scripts/main.sh`,
@@ -50,7 +50,7 @@ test('throws an error when OIDC token is invalid', async (t) => {
           reject(new Error('Expected an error but did not get one.'));
         }
 
-        t.equal(error.code, 1);
+        tapzero.equal(error.code, 1);
         resolve();
       },
     );

--- a/test/index.js
+++ b/test/index.js
@@ -44,7 +44,7 @@ test('correct version should appear in dry-run output', async (tapzero) => {
 test('throws an error when OIDC token is invalid', async (tapzero) => {
   await new Promise((resolve, reject) => {
     exec(
-      `ACTIONS_ID_TOKEN_REQUEST_URL=${FAKE} ACTIONS_ID_TOKEN_REQUEST_TOKEN=${FAKE} STAGED_PUBLISH=true ./scripts/main.sh`,
+      `ACTIONS_ID_TOKEN_REQUEST_URL=${FAKE} ACTIONS_ID_TOKEN_REQUEST_TOKEN=${FAKE} STAGED_PUBLISH=true PUBLISH_NPM_TAG=latest ./scripts/main.sh`,
       (error) => {
         if (!error) {
           reject(new Error('Expected an error but did not get one.'));

--- a/test/index.js
+++ b/test/index.js
@@ -19,7 +19,7 @@ test('should only have 15 devDependency from now until forever', async (tapzero)
 
 test('should not error when performing a dry-run publish', async (tapzero) => {
   await new Promise((resolve, reject) => {
-    exec('./scripts/main.sh', (error) => {
+    exec('PUBLISH_NPM_TAG=latest ./scripts/main.sh', (error) => {
       if (error) {
         reject(new Error(error));
       }
@@ -31,7 +31,7 @@ test('should not error when performing a dry-run publish', async (tapzero) => {
 
 test('correct version should appear in dry-run output', async (tapzero) => {
   await new Promise((resolve, reject) => {
-    exec('./scripts/main.sh', (error, stdout) => {
+    exec('PUBLISH_NPM_TAG=latest ./scripts/main.sh', {}, (error, stdout) => {
       if (error) {
         reject(new Error(error));
       }

--- a/test/index.js
+++ b/test/index.js
@@ -4,7 +4,6 @@ const { test } = require('tapzero');
 const packageJson = require('../package.json');
 
 const { devDependencies, version } = packageJson;
-const INVALID_TOKEN = 'should error when token is invalid';
 const FAKE = 'FAKE';
 
 test('should not have dependencies from now until forever', async (tapzero) => {
@@ -42,14 +41,18 @@ test('correct version should appear in dry-run output', async (tapzero) => {
   });
 });
 
-test('should error when token is invalid', async (tapzero) => {
+test('throws an error when OIDC token is invalid', async (t) => {
   await new Promise((resolve, reject) => {
-    exec(`YARN_NPM_AUTH_TOKEN=${FAKE} ./scripts/main.sh`, (error) => {
-      if (!error) {
-        reject(new Error(INVALID_TOKEN));
-      }
-      tapzero.equal(error.code, 1);
-      resolve();
-    });
+    exec(
+      `ACTIONS_ID_TOKEN_REQUEST_URL=${FAKE} ACTIONS_ID_TOKEN_REQUEST_TOKEN=${FAKE} STAGED_PUBLISH=true ./scripts/main.sh`,
+      (error) => {
+        if (!error) {
+          reject(new Error('Expected an error but did not get one.'));
+        }
+
+        t.equal(error.code, 1);
+        resolve();
+      },
+    );
   });
 });


### PR DESCRIPTION
This adds support for [NPM staged publishing](https://docs.npmjs.com/staged-publishing) with [OIDC](https://docs.npmjs.com/trusted-publishers). It works as follows:

- The action detects if OIDC is available (i.e., if the workflow has `id-token: write` permission), and uses it to perform a staged publish.
- If OIDC is not available (i.e., if the workflow does not have the `id-token: write` permission), it falls back to a dry-run.
- A package must be published to set up OIDC, so for publishing a package for the first time, a fallback exists where the action looks at the provided NPM token, but _only_ if the package is not published yet.
   - If a package _is_ published, and an NPM token is set, the NPM token is simply ignored.
   - This lets us perform an initial publish with a short-lived NPM token, and immediately revoke the token after publish. Then we can set up OIDC for any subsequent publishes.

Pending a release of a new Yarn version.

## Breaking changes

- Publishing with NPM tokens is no longer possible, with the exception of the initial publish of a package (to allow OIDC to be set up).
- Older versions of Yarn, and NPM are no longer supported.
- The action now requires `id-token: write` permission to publish.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes release authentication and publish commands for all consumers; workflows must grant `id-token: write` and meet new Yarn constraints or publishes will dry-run or fail.
> 
> **Overview**
> **Breaking change:** publishing now targets **OIDC trusted publishing** with **npm staged releases** and **provenance**, instead of routine `npm-token` auth.
> 
> `publish.sh` is refactored to require **Yarn ≥ 4.16**, choose auth from registry state: **token only for the first publish** of an unpublished package, then **ignore the token** and use OIDC when `ACTIONS_ID_TOKEN_REQUEST_URL` is set (`yarn npm publish` with `--provenance`, and `--staged` when `staged-publish` is true). With neither token nor OIDC, it **packs only** and sets a **`dry-run` output** so later steps (pkdiff, reports, artifacts) run off that flag—not “missing npm-token” alone.
> 
> `action.yml` adds **`staged-publish`** (default true) and wires **`STAGED_PUBLISH`**. **README** documents OIDC (`id-token: write`), one-time token bootstrap, and the Yarn version requirement. **Integration tests** point at `MetaMask/snaps` / pinned refs, enable **corepack**, and set env vars explicitly; unit tests expect **OIDC failure** instead of invalid NPM token.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8cc44c8407ea7e3da33eb7a04cb9e7bca67fff4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->