### PR TITLE
chore: Bump Yarn to `4.16.0`

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -15,6 +15,8 @@ logFilters:
   - code: YN0004
     level: discard
 
+nodeLinker: node-modules
+
 # Configure the NPM minimal age gate to 3 days, meaning packages must be at
 # least 3 days old to be installed.
 npmMinimalAgeGate: 4320 # 3 days (in minutes)
@@ -25,8 +27,6 @@ npmPreapprovedPackages:
   - '@metamask/*'
   - '@metamask-previews/*'
   - '@lavamoat/*'
-
-nodeLinker: node-modules
 
 plugins:
   - path: .yarn/plugins/@yarnpkg/plugin-allow-scripts.cjs

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "prettier-plugin-packagejson": "^3.0.2",
     "tapzero": "^0.6.1"
   },
-  "packageManager": "yarn@4.15.0",
+  "packageManager": "yarn@4.16.0",
   "engines": {
     "node": "^22.14.0 || >=24"
   },


### PR DESCRIPTION
Yarn 4.16.0 has support for staged NPM publishing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tooling-only version bump and a cosmetic YAML reorder; no runtime or publish-action logic changes in this diff.
> 
> **Overview**
> Bumps the repo’s Yarn toolchain from **4.15.0** to **4.16.0** via the `packageManager` field in `package.json`, aligning local/CI installs with the newer release (notably **staged NPM publishing** support mentioned in the PR).
> 
> `.yarnrc.yml` only **reorders** the existing `nodeLinker: node-modules` setting (same value, no config behavior change).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0cfbf846a383b2136209dddd62710a0aad271c89. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->