### PR TITLE
docs: Update action version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: MetaMask/action-npm-publish@v4
+      - uses: MetaMask/action-npm-publish@v6
 ```
 
 This uses `--provenance` and (by default) `--staged` for publishing.
@@ -41,7 +41,7 @@ This uses `--provenance` and (by default) `--staged` for publishing.
 NPM requires a package to exist on the registry before OIDC can be configured for it, so the very first publish must use a token:
 
 ```yaml
-- uses: MetaMask/action-npm-publish@v4
+- uses: MetaMask/action-npm-publish@v6
   with:
     npm-token: ${{ secrets.NPM_TOKEN }}
 ```
@@ -53,7 +53,7 @@ Once the package has been published at least once, the token is ignored and OIDC
 If neither a token nor OIDC is available, packages will be prepared for publishing but no publishing will actually occur:
 
 ```yaml
-- uses: MetaMask/action-npm-publish@v4
+- uses: MetaMask/action-npm-publish@v6
 ```
 
 ### Slack announce
@@ -63,7 +63,7 @@ You can optionally send deployment announcements to Slack by providing a `slack-
 The absolute minimum configuration for this is:
 
 ```yaml
-- uses: MetaMask/action-npm-publish@v4
+- uses: MetaMask/action-npm-publish@v6
   with:
     slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 ```
@@ -78,7 +78,7 @@ We've added the ability to customize the message posted in Slack and those optio
 example:
 
 ```yaml
-- uses: MetaMask/action-npm-publish@v4
+- uses: MetaMask/action-npm-publish@v6
   with:
     slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
     icon-url: https://ricky.codes/me.jpg


### PR DESCRIPTION
Noticed the README was referring to `v4`, while the latest version is now `v6`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to example action pins; no runtime or publish behavior is modified.
> 
> **Overview**
> Updates all **README** usage examples so they reference **`MetaMask/action-npm-publish@v6`** instead of **`@v4`**, matching the current release referenced in the PR description.
> 
> Affected sections: OIDC publish, initial token publish, dry run, and both Slack announce examples. No workflow or action code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f6598bdb67e014eea9a19baf2bb107b649a7d29. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->