### PR TITLE
feat: Update Slack message to link to staged publish instructions

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -71,7 +71,7 @@ runs:
         REPOSITORY: ${{ github.repository }}
         RUN_ID: ${{ github.run_id }}
       run: |
-        DEFAULT_TEXT="\`$NAME_VERSION\` is awaiting deployment :rocket: \n <https://github.com/$REPOSITORY/actions/runs/$RUN_ID/|→ Click here to review deployment>"
+        DEFAULT_TEXT="\`$NAME_VERSION\` is awaiting deployment :rocket: \n <https://github.com/$REPOSITORY/actions/runs/$RUN_ID/|→ Click here to review deployment> \n <https://www.notion.so/metamask-consensys/NPM-publishing-with-OIDC-374f86d67d68805583e9f824ff5ff18e#374f86d67d68807da68cf75485fd70d2|→ See instructions for approving staged packages here>"
         FINAL_TEXT="$DEFAULT_TEXT"
         if [[ ! "$SUBTEAM_TEXT" == "" ]]; then
           FINAL_TEXT="<!subteam^$SUBTEAM_TEXT> $DEFAULT_TEXT"


### PR DESCRIPTION
This adds a link to the instructions for publishing staged packages to the Slack message. The final message looks like this:

@metamask-npm-publishers `package-name@0.3.1` is awaiting deployment :rocket:
 → [Click here to review deployment](#)
 → [See instructions for approving staged packages here](#)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only change to Slack notification text; no auth, publish, or workflow logic is modified.
> 
> **Overview**
> The staged-publish Slack notification now includes a **second link** in `action.yml`'s `final-text` step, pointing reviewers to Notion for **approving staged NPM packages**, alongside the existing GitHub Actions run link.
> 
> No publish logic, webhooks, or channel behavior changes—only the default message body when `slack-webhook-url` is set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d3c931c3f0b71045c66a6efafe47e20e78d0a0f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->