### PR TITLE
feat: Add explicit `dry-run` parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add `dry-run` option ([#122](https://github.com/MetaMask/action-npm-publish/pull/122))
+  - If omitted, it defaults to `true` if required credentials are missing, `false` otherwise. This matches current behavior.
+	- When set to `false`, this will abort when authorization is missing (rather than assuming a dry run was intended, as it does today)
 
 ## [6.2.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
 ### Added
+
 - Add `dry-run` option ([#122](https://github.com/MetaMask/action-npm-publish/pull/122))
   - If omitted, it defaults to `true` if required credentials are missing, `false` otherwise. This matches current behavior.
   - When set to `false`, this will abort when authorization is missing (rather than assuming a dry run was intended, as it does today)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add `dry-run` option ([#122](https://github.com/MetaMask/action-npm-publish/pull/122))
   - If omitted, it defaults to `true` if required credentials are missing, `false` otherwise. This matches current behavior.
-	- When set to `false`, this will abort when authorization is missing (rather than assuming a dry run was intended, as it does today)
+  - When set to `false`, this will abort when authorization is missing (rather than assuming a dry run was intended, as it does today)
 
 ## [6.2.1]
 

--- a/README.md
+++ b/README.md
@@ -50,11 +50,15 @@ Once the package has been published at least once, the token is ignored and OIDC
 
 ### Dry run mode
 
-If neither a token nor OIDC is available, packages will be prepared for publishing but no publishing will actually occur:
+In dry run mode, packages will be prepared for publishing but no publishing will actually occur. No token or OIDC is necessary.
 
 ```yaml
 - uses: MetaMask/action-npm-publish@v6
+  with:
+    dry-run: true
 ```
+
+If neither a token nor OIDC is available, `dry-run` will default to `true`, otherwise it defaults to `false`.
 
 ### Slack announce
 

--- a/action.yml
+++ b/action.yml
@@ -33,6 +33,9 @@ inputs:
   channel:
     description: 'The Slack channel to post in'
     required: false
+  dry-run:
+    description: 'Enables dry run mode, which prepares the package for publishing but does not publish it'
+    required: false
 
 runs:
   using: 'composite'
@@ -46,6 +49,7 @@ runs:
         STAGED_PUBLISH: ${{ inputs.staged-publish }}
         PROVENANCE: ${{ inputs.provenance }}
         REPOSITORY_VISIBILITY: ${{ github.event.repository.visibility }}
+        DRY_RUN: ${{ inputs.dry-run }}
     - id: install-pkdiff
       if: steps.publish.outputs.dry-run == 'true'
       shell: bash

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -53,7 +53,7 @@ configure_publish() {
   #    provided, perform a dry run.
   # 4. If the package has already been published and OIDC is available, use
   #    OIDC to publish.
-  # 4. If the package has already been published and OIDC is not available,
+  # 5. If the package has already been published and OIDC is not available,
   #    perform a dry run.
   #
   # If `DRY_RUN` is explicitly set to `false` and a publish is attempted

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -39,36 +39,52 @@ get_package_info() {
 configure_publish() {
   PACK_CMD="yarn pack --out /tmp/%s-%v.tgz"
 
-  # Determine the publish command and whether to perform a dry run. It works
-  # as follows:
-  # 1. If a token is provided, and the package has not been published before,
-  #    use the token for the initial publish.
-  # 2. If a token is provided, but the package has already been published,
-  #    ignore the token and fall back to OIDC (if available) for subsequent
-  #    publish.
-  # 3. If no token is provided, use OIDC if available.
-  # 4. If neither a token nor OIDC is available, perform a dry run.
-  if [[ -n "$YARN_NPM_AUTH_TOKEN" && -z "$PUBLISHED_PACKAGE_VERSION" ]]; then
-    echo "Notice: Package not yet published. Using token for initial publish."
-    PUBLISH_CMD="yarn npm publish --tag $PUBLISH_NPM_TAG"
-    DRY_RUN="false"
-  elif [[ -n "$YARN_NPM_AUTH_TOKEN" ]]; then
-    echo "Notice: Package already published. Ignoring token and falling back to OIDC."
-    unset YARN_NPM_AUTH_TOKEN
-  fi
-
   # Build publish flags for OIDC publishing.
   PUBLISH_FLAGS=("--tag" "$PUBLISH_NPM_TAG")
   [[ "$STAGED_PUBLISH" = "true" ]] && PUBLISH_FLAGS+=("--staged")
   [[ "$PROVENANCE" = "true" && "$REPOSITORY_VISIBILITY" = "public" ]] && PUBLISH_FLAGS+=("--provenance")
 
-  if [[ -z "$DRY_RUN" ]]; then
-    if [[ -n "$ACTIONS_ID_TOKEN_REQUEST_URL" ]]; then
-      PUBLISH_CMD="yarn npm publish ${PUBLISH_FLAGS[*]}"
-      DRY_RUN="false"
+  # Determine the publish command and whether to perform a dry run. It works
+  # as follows:
+  # 1. If `DRY_RUN` is explicitly set to `true`, perform a dry run.
+  # 2. If the package has not been published before and a token has been
+  #    provided, use the provided token for the initial publish.
+  # 3. If the package has not been published before and a token has not been
+  #    provided, perform a dry run.
+  # 4. If the package has already been published and OIDC is available, use
+  #    OIDC to publish.
+  # 4. If the package has already been published and OIDC is not available,
+  #    perform a dry run.
+  #
+  # If `DRY_RUN` is explicitly set to `false` and a publish is attempted
+  # without necessary authorization, abort with an error.
+  if [[ $DRY_RUN = "true" ]]; then
+    echo "Notice: Performing a dry run."
+  elif [[ -z "$PUBLISHED_PACKAGE_VERSION" ]]; then
+    if [[ -z "$YARN_NPM_AUTH_TOKEN" && "$DRY_RUN" = "false" ]]; then
+      echo "::error::'npm-token' not provided for initial publish."
+      exit 1
+    elif [[ -z "$YARN_NPM_AUTH_TOKEN" ]]; then
+      echo "Notice: Token is not available for initial publish. Performing a dry run."
+      DRY_RUN="true"
     else
+      echo "Notice: Package not yet published. Using npm token for initial publish."
+      PUBLISH_CMD="yarn npm publish --tag $PUBLISH_NPM_TAG"
+      DRY_RUN="false"
+    fi
+  else
+	  # Unset auth token because it can interfere with OIDC publishing (see #123)
+	  unset YARN_NPM_AUTH_TOKEN
+    if [[ -z "$ACTIONS_ID_TOKEN_REQUEST_URL" && "$DRY_RUN" = "false" ]]; then
+      echo "::error:: OIDC is not available for publish."
+      exit 1
+    elif [[ -z "$ACTIONS_ID_TOKEN_REQUEST_URL" ]]; then
       echo "Notice: OIDC is not available. Performing a dry run."
       DRY_RUN="true"
+    else
+      echo "Notice: Initial package version already published. Using OIDC to publish."
+      PUBLISH_CMD="yarn npm publish ${PUBLISH_FLAGS[*]}"
+      DRY_RUN="false"
     fi
   fi
 

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -73,8 +73,8 @@ configure_publish() {
       DRY_RUN="false"
     fi
   else
-	  # Unset auth token because it can interfere with OIDC publishing (see #123)
-	  unset YARN_NPM_AUTH_TOKEN
+    # Unset auth token because it can interfere with OIDC publishing (see #123)
+    unset YARN_NPM_AUTH_TOKEN
     if [[ -z "$ACTIONS_ID_TOKEN_REQUEST_URL" && "$DRY_RUN" = "false" ]]; then
       echo "::error:: OIDC is not available for publish."
       exit 1


### PR DESCRIPTION
Add an explicit input for enabling or disabling `dry-run`. Currently the way `dry-run` is enabled is confusing, and missing authorization ends up enabling dry run rather than aborting with an error (hiding the problem). This parameter simplifies enabling dry run mode, and it provides much better error messages upon missing authorization when explicitly disabled.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes publish/auth decision logic for npm OIDC and token flows; misconfigured workflows may now fail where they previously appeared to succeed in dry-run mode.
> 
> **Overview**
> Adds an optional **`dry-run`** action input (wired to `DRY_RUN` in `publish.sh`) so workflows can turn dry-run mode on explicitly instead of inferring it only from missing credentials.
> 
> **`configure_publish`** is reordered: `dry-run: true` wins first; initial publish still uses an npm token when present; for already-published packages the token is unset and OIDC is used when available. If credentials are missing, behavior still defaults to a dry run when the input is omitted, but **`dry-run: false`** now **fails the job** with clear errors (missing `npm-token` on first publish, or missing OIDC on later publishes) instead of silently packing only.
> 
> README and CHANGELOG document the input and defaulting rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94cae63da6e64387ea2cdf4b13fa64ba14edcc88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->