### PR TITLE
fix: Unset npm token when package is already published

### DIFF
--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -54,6 +54,7 @@ configure_publish() {
     DRY_RUN="false"
   elif [[ -n "$YARN_NPM_AUTH_TOKEN" ]]; then
     echo "Notice: Package already published. Ignoring token and falling back to OIDC."
+    unset YARN_NPM_AUTH_TOKEN
   fi
 
   # Build publish flags for OIDC publishing.


### PR DESCRIPTION
## Summary

- When a package is already published and we fall back to OIDC, unset `YARN_NPM_AUTH_TOKEN` to avoid it interfering with the OIDC publish flow.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line change in CI publish scripting with no auth logic redesign; only clears env when OIDC is intended.
> 
> **Overview**
> When a package is **already on npm** and the publish script switches from token auth to **OIDC**, it now runs **`unset YARN_NPM_AUTH_TOKEN`** so a leftover token cannot override or break the OIDC publish path.
> 
> This matches the existing “ignore token, fall back to OIDC” branch in `scripts/publish.sh` with an explicit env cleanup before `yarn npm publish` runs with OIDC flags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d350a7a8bb57a0df8dba9d7ecd083070e17bbcee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->