### PR TITLE
refactor: simplify `publish.sh` after pre-flight skip check

### DIFF
--- a/scripts/main.sh
+++ b/scripts/main.sh
@@ -54,7 +54,7 @@ publish_monorepo() {
   echo "Notice: Publishing ${#names[@]} package(s): ${pending//$'\n'/, }."
 
   yarn workspaces foreach --all "${include_args[@]}" --no-private --verbose \
-    exec "$script_path/publish.sh" true
+    exec "$script_path/publish.sh"
 }
 
 if [[ "$(jq 'has("workspaces")' package.json)" = "true" ]]; then

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -83,26 +83,7 @@ configure_publish() {
   fi
 }
 
-publish_polyrepo() {
-  if [[ "$DRY_RUN" = "true" ]]; then
-    $PACK_CMD
-    exit 0
-  fi
-
-  $PUBLISH_CMD
-}
-
-publish_monorepo() {
-  # Get the published version for the specified tag, if it exists. Note that
-  # we're `cd`ing into /tmp before running `npm view` to avoid any issues with
-  # Corepack detecting Yarn.
-  LATEST_PACKAGE_VERSION=$(cd /tmp && npm view "$PACKAGE_NAME" dist-tags --workspaces false --json 2>/dev/null | jq --raw-output --arg tag "$PUBLISH_NPM_TAG" '.[$tag] // empty' || echo "")
-
-  if [ "$LATEST_PACKAGE_VERSION" = "$CURRENT_PACKAGE_VERSION" ]; then
-    echo "Notice: This module is already published at $CURRENT_PACKAGE_VERSION. Aborting publish."
-    exit 0
-  fi
-
+publish() {
   if [[ "$DRY_RUN" = "true" ]]; then
     $PACK_CMD
   else
@@ -114,13 +95,7 @@ main() {
   check_requirements
   get_package_info
   configure_publish
-
-  IS_MONOREPO="$1"
-  if [[ "$IS_MONOREPO" = "true" ]]; then
-    publish_monorepo
-  else
-    publish_polyrepo
-  fi
+  publish
 }
 
 main "$@"


### PR DESCRIPTION
## Summary

Follow-up to #127. The `needs-publish.sh` pre-flight already decides which workspaces actually need publishing, so `publish.sh`'s `LATEST_PACKAGE_VERSION` check in `publish_monorepo` can never trigger for a selected workspace — it was dead code.

Removing it makes `publish_monorepo` and `publish_polyrepo` identical, so they're collapsed into a single `publish()` function and the `IS_MONOREPO` arg threading is dropped. `main.sh` no longer passes the now-unused `true` arg to `publish.sh`.

No behaviour change.