### PR TITLE
ci: fix publish environment name

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -65,7 +65,7 @@ jobs:
 
   publish-release:
     name: Publish release
-    environment: npm-publish
+    environment: action-publish
     needs: announce-release
     permissions:
       contents: read


### PR DESCRIPTION
Fixes the `environment` name from `npm-publish` to `action-publish`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single workflow environment rename with no application or security logic changes; only affects which GitHub environment protections apply to the publish job.
> 
> **Overview**
> Renames the GitHub Actions **deployment environment** on the `publish-release` job from `npm-publish` to `action-publish`.
> 
> This aligns the environment gate with the intended release publish setup so approval rules and secrets attach to the correct environment when the reusable workflow runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9cf44d4040d624ad828b44da71edb4e9dfc9b006. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->